### PR TITLE
fix: affirmative voice in ch02 — direct reader toward action

### DIFF
--- a/manuscript/ch02-the-bible.md
+++ b/manuscript/ch02-the-bible.md
@@ -1,0 +1,83 @@
+# Hour 2: The Bible
+
+Q: Is the Bible the word of God?
+A: Yes. But that doesn't mean what most people think it means.
+
+## Commentary
+
+You've made it to Hour 2, which means you're still here. Good. Because this chapter is about the book that the rest of this book won't stop quoting, and you need to understand what you're holding so that everything after this lands the way it should.
+
+The Bible is not a rulebook. It's not an instruction manual. It's not a single document written by one author with one message. And it is absolutely not a weapon to be aimed at people you disagree with.
+
+So what is it?
+
+## What the Bible actually is
+
+The Bible is a library. Sixty-six books, written by roughly forty authors, across approximately 1,500 years. It contains history, poetry, law, prophecy, letters, biography, and apocalyptic vision. Some of it is literal. Some of it is metaphorical. Some of it is both at the same time, and God expects you to exercise the critical thinking to discern the difference.
+
+> All Scripture is breathed out by God and profitable for teaching, for reproof, for correction, and for training in righteousness.
+— [2 Timothy 3:16 ESV][1]
+
+"Breathed out by God" does not mean God dictated it word for word like a CEO sending a memo. The authors of the Bible were real people with real personalities, writing in specific historical contexts for specific audiences. Paul's letters sound nothing like the Psalms. The Gospel of John reads nothing like Leviticus. That's not a flaw — it's the point. God worked *through* human beings, not around them.
+
+This matters because the moment you treat the Bible as a flat document where every sentence carries identical weight and context doesn't matter, you end up with absurdities. You end up arguing that wearing mixed fabrics is a sin ([Leviticus 19:19][2]) while ignoring that Jesus declared all foods clean ([Mark 7:19][3]). You end up using a verse from Leviticus to condemn someone while eating shrimp for dinner.
+
+## What the Bible is not
+
+**It is not a magic 8-ball.** You cannot flip to a random page, point at a verse, and call it God's personal message to you about whether to take that job or date that person. That's superstition dressed up as faith.
+
+**It is not a weapon.** Satan himself quoted Scripture when tempting Jesus in the wilderness ([Matthew 4:6][4]). If the devil can cherry-pick Bible verses to make a point, so can anyone. A verse ripped from its context can be made to say almost anything. People have used the Bible to justify slavery, to oppress women, to start wars, and to hoard wealth. Every single one of those uses required ignoring the rest of what the Bible says.
+
+> Even the demons believe — and shudder!
+— [James 2:19 ESV][5]
+
+Knowing the Bible is not the same as understanding it. And understanding it is not the same as living it.
+
+**It is not a science textbook.** Genesis was not written to compete with evolutionary biology. The creation account tells you *who* created and *why*. Science tells you *how* and *when*. These are different questions, and the Bible was never trying to answer the ones that belong to science.
+
+## How to actually read it
+
+Most people approach the Bible one of two ways. Either they never read it at all and rely on what other people tell them it says, or they read isolated verses on Instagram and build an entire theology around them. Both approaches are dangerous.
+
+Here's a better way.
+
+**Read whole books, not verses.** A single verse is like a single sentence pulled from a novel. It might sound meaningful on its own, but you're missing the plot. When Paul writes "I can do all things through him who strengthens me" ([Philippians 4:13][6]), he's not promising you'll get a promotion. He's writing from prison, telling the Philippians he's learned to be content whether he has plenty or nothing. The verse is about endurance, not ambition.
+
+**Know who's talking, and to whom.** When God tells Joshua to conquer Jericho, that is not a standing order for you to go take what you want. When Jesus tells a rich young man to sell everything he owns ([Mark 10:21][7]), he's addressing a specific person's specific idol. When Paul tells women to be silent in church ([1 Corinthians 14:34][8]), he's writing to a specific congregation dealing with specific disruptions in a specific cultural context.
+
+Does that mean those passages have nothing to say to you? No. But it means you have to think about *why* something was said before you decide *what* it means for your life. That requires effort. It requires humility. And it requires admitting you might have been reading it wrong.
+
+**Let Scripture interpret Scripture.** If your reading of one verse contradicts the clear message of dozens of others, you're probably misreading the one. The Bible has tensions — places where different authors emphasize different things — but it doesn't contradict itself on the big stuff. Love God. Love people. Act justly. Show mercy. Walk humbly. If your interpretation leads you away from those themes, go back and read again.
+
+**Read the parts that make you uncomfortable.** This is not optional. If you only read the verses that confirm what you already believe, you're not reading the Bible — you're reading yourself. The passages that challenge you, offend you, or confuse you are exactly the ones you need to wrestle with.
+
+> For the word of God is living and active, sharper than any two-edged sword, piercing to the division of soul and of spirit, of joints and of marrow, and discerning the thoughts and intentions of the heart.
+— [Hebrews 4:12 ESV][9]
+
+A sword cuts. If the Bible has never cut you — never made you question your own assumptions, never convicted you of something you'd rather not face — you might not have actually read it yet.
+
+## Why this matters for the rest of the book
+
+Every chapter in this book points back to Scripture. Not because we're blindly deferring to authority, but because the Bible is the primary source. Everything else — sermons, theology books, podcasts, this book — is commentary. And commentary, no matter how well-intentioned, is filtered through human limitations.
+
+The preface of this book told you to read the Bible for yourself after you finish here. That wasn't a suggestion. It was the whole point. This book is a map. The Bible is the territory. And maps are useful, but they're no substitute for walking the ground yourself.
+
+If you disagree with something in this book, good. Open the Bible and check. If a pastor tells you something that sounds off, open the Bible and check. If a friend quotes a verse to win an argument, open the Bible and read the three chapters around it.
+
+God gave you a mind. Use it.
+
+## Questions to sit with
+
+* When was the last time you read a full book of the Bible — not a verse, not a chapter, but an entire book? If the answer is "never," what has been stopping you?
+* Have you ever used a Bible verse to justify something you wanted to do? What would happen if you read the full context of that verse?
+* What part of the Bible makes you most uncomfortable? That's probably where you should start.
+
+[1]: https://www.esv.org/2+Timothy+3/
+[2]: https://www.esv.org/Leviticus+19/
+[3]: https://www.esv.org/Mark+7/
+[4]: https://www.esv.org/Matthew+4/
+[5]: https://www.esv.org/James+2/
+[6]: https://www.esv.org/Philippians+4/
+[7]: https://www.esv.org/Mark+10/
+[8]: https://www.esv.org/1+Corinthians+14/
+[9]: https://www.esv.org/Hebrews+4/


### PR DESCRIPTION
## Summary

Two editorial fixes per Marty's feedback on voice:

- **"if you don't understand... will land wrong"** → **"you need to understand... lands the way it should"** — directs the reader toward what to do instead of warning about what will go wrong
- **"the authors expected you to be smart enough"** → **"God expects you to exercise the critical thinking"** — reframes as God's expectation (theologically accurate since the authors didn't know their texts would become the Bible) and affirms the reader's capacity

Both changes preserve the strong, direct tone while shifting from negative framing to affirmative direction.

## Test plan

- [ ] Read both passages in context — do they still land with conviction?

🤖 Generated with [Claude Code](https://claude.com/claude-code)