### PR TITLE
Draft Chapter 8: Moses and the Law

### DIFF
--- a/manuscript/ch08-moses-and-the-law.md
+++ b/manuscript/ch08-moses-and-the-law.md
@@ -27,7 +27,7 @@ Moses is eighty years old. He's a fugitive — he killed an Egyptian overseer de
 
 God doesn't accept any of it. The mission doesn't wait for you to feel ready. Moses goes.
 
-This is the same pattern as Abraham — a person who didn't choose the assignment, didn't feel qualified for it, and went anyway. Faith is not confidence. It's obedience despite the absence of confidence.
+This is the same pattern as Abraham — a person who didn't choose the assignment, didn't feel qualified for it, and went anyway. Faith is not confidence. It's choosing to move forward when every instinct says you're not ready.
 
 ## The Exodus
 

--- a/manuscript/ch08-moses-and-the-law.md
+++ b/manuscript/ch08-moses-and-the-law.md
@@ -1,0 +1,157 @@
+# Hour 8: Moses and the Law
+
+Q: Why did God give rules He knew people would break?
+A: Because you can't choose the mission if no one has shown you what the mission looks like.
+
+## Commentary
+
+Hour 7 ended with a covenant. God chose one man — Abraham — and built a promise around him: your descendants will become a great nation, and through that nation, the world will be blessed.
+
+Between Abraham and where this chapter picks up, several generations pass. Isaac has Jacob. Jacob has twelve sons. One of them, Joseph, is sold into slavery by his own brothers, ends up in Egypt, rises to become Pharaoh's right hand, and eventually brings his entire family to Egypt to survive a famine. It's a remarkable story — but the part that matters for the arc is the ending. Israel's family settles in Egypt. They grow. They multiply. And eventually, a new Pharaoh rises who doesn't remember Joseph.
+
+> Now there arose a new king over Egypt, who did not know Joseph. And he said to his people, "Behold, the people of Israel are too many and too mighty for us."
+— [Exodus 1:8-9 ESV][1]
+
+The covenant people become slaves. For four hundred years.
+
+## The burning bush
+
+God's response to four centuries of slavery is not an army or a natural disaster. It's one man standing in front of a bush that burns without being consumed.
+
+> Then the LORD said, "I have surely seen the affliction of my people who are in Egypt and have heard their cry because of their taskmasters. I know their sufferings, and I have come down to deliver them."
+— [Exodus 3:7-8 ESV][2]
+
+Moses is eighty years old. He's a fugitive — he killed an Egyptian overseer decades earlier and fled to the wilderness. He's not a leader, not a priest, not a warrior. He has a stutter. When God tells him to go back to Egypt and demand Pharaoh release an entire nation of slaves, Moses does what most honest people would do: he argues.
+
+"Who am I that I should go to Pharaoh?" ([Exodus 3:11][3]). "What if they don't believe me?" ([Exodus 4:1][4]). "I am not eloquent... I am slow of speech" ([Exodus 4:10][5]).
+
+God doesn't accept any of it. The mission doesn't wait for you to feel ready. Moses goes.
+
+This is the same pattern as Abraham — a person who didn't choose the assignment, didn't feel qualified for it, and went anyway. Faith is not confidence. It's obedience despite the absence of confidence.
+
+## The Exodus
+
+What follows is the most dramatic sequence of divine intervention in the entire Bible. Ten plagues. Water to blood. Frogs, gnats, flies. Livestock disease, boils, hail, locusts, darkness. And finally, the death of every firstborn in Egypt — except in homes where lamb's blood has been painted on the doorframe.
+
+> For I will pass through the land of Egypt that night, and I will strike all the firstborn in the land of Egypt, both man and beast; and on all the gods of Egypt I will execute judgments: I am the LORD. The blood shall be a sign for you, on the houses where you are. And when I see the blood, I will pass over you, and no plague shall fall upon you to destroy you, when I strike the land of Egypt.
+— [Exodus 12:12-13 ESV][6]
+
+The Passover. This event becomes the foundational act of remembrance for Israel — the night God drew a line between those under the covenant and those who were not. Centuries later, Jesus will be crucified during Passover. That timing is not accidental.
+
+Pharaoh relents. Israel leaves Egypt. And then Pharaoh changes his mind and sends his army. The Israelites find themselves trapped between the army and the Red Sea.
+
+> And Moses said to the people, "Fear not, stand firm, and see the salvation of the LORD, which he will work for you today."
+— [Exodus 14:13 ESV][7]
+
+God parts the sea. Israel walks through on dry ground. The Egyptian army follows and is destroyed. It is the definitive act of rescue in the Old Testament.
+
+Here is the question this demands, given the framework of this book: if God could do *that*, why doesn't He intervene like that today?
+
+The answer is core tenet #2. God's direct interventions had a defined arc — a progression building toward Jesus. The Exodus was part of that arc. God was building a people, establishing a covenant nation, and setting the stage for everything that would follow. These interventions were not random acts of power. They were steps in a plan that had a beginning, a middle, and an end. The end came with Christ. After that, humanity has what it needs. The test is ours to pass or fail without the sea parting for us.
+
+That might not satisfy you. It shouldn't be easy. The distance between a God who parts oceans and a God who watches in silence is the central tension of the entire Bible. We will come back to it.
+
+## The Law
+
+Six weeks after the Red Sea, Israel arrives at Mount Sinai. And God gives Moses the Law.
+
+The Ten Commandments are the most famous part, but they are only the beginning. Exodus, Leviticus, Numbers, and Deuteronomy contain hundreds of laws — civil, ceremonial, moral, agricultural, dietary, judicial. How to sacrifice. How to handle disease. How to settle property disputes. How to treat slaves. What to eat. What to wear. When to rest. How to worship.
+
+To a modern reader, it's overwhelming. And the obvious question is: why?
+
+Why would God, who values free will and human agency, hand down a legal code so detailed it governs what fabric you wear? Why give rules you know people will break?
+
+Because the Law is not the cure. The Law is the diagnosis.
+
+> Through the law comes knowledge of sin.
+— [Romans 3:20 ESV][8]
+
+Without the Law, sin is vague. It's "choosing self over mission" — true, but abstract. The Law makes it specific. Don't murder. Don't steal. Don't covet what belongs to someone else. Don't lie under oath. Honor your parents. Rest one day in seven. Love the foreigner living among you as yourself ([Leviticus 19:34][9]).
+
+The Law takes the mission and translates it into behavior. It gives Israel — and through them, eventually, the world — a concrete picture of what faithful living looks like. Not because following every rule earns God's approval, but because you can't choose the right path if no one has shown you what the path looks like.
+
+Paul understood this:
+
+> Is the law then contrary to the promises of God? Certainly not! For if a law had been given that could give life, then righteousness would indeed be by the law. But the Scripture imprisoned everything under sin, so that the promise by faith in Jesus Christ might be given to those who believe.
+— [Galatians 3:21-22 ESV][10]
+
+The Law was never meant to save anyone. It was meant to show you why you need saving. It holds up a mirror and says: here is the standard, and here is how far you fall short. That gap — between what the Law demands and what you can deliver — is exactly where grace enters the story. But grace is a few chapters away. Israel had to live under the Law first, long enough to learn the lesson.
+
+## The golden calf
+
+The lesson didn't take long to fail.
+
+Moses goes up Mount Sinai to receive the Law. He's gone forty days. While he's on the mountain — literally while God is giving the rules — the people at the base do this:
+
+> And he received the gold from their hand and fashioned it with a graving tool and made a golden calf. And they said, "These are your gods, O Israel, who brought you up out of the land of Egypt!"
+— [Exodus 32:4 ESV][11]
+
+Six weeks after the Red Sea parted. Six weeks after the most spectacular rescue in human history. And they build a golden idol and throw a party.
+
+If you've been reading since Hour 7, this should feel familiar. It's the same pattern. God provides. Humanity rebels. Not eventually. Not after careful deliberation. Immediately. Noah got drunk after the flood. The Israelites built a calf after the Exodus. The proximity of the miracle to the failure is the point. No amount of evidence — no parted seas, no pillars of fire, no manna from the sky — is enough to override the human capacity to choose self over mission.
+
+Moses comes down from the mountain, sees the calf, and shatters the stone tablets. Three thousand people die in the aftermath. God nearly abandons the entire project. Moses talks Him out of it.
+
+Then God gives the Law again. On new tablets. Because the mission continues, even when the people fail it.
+
+## The wilderness
+
+Israel spends forty years in the wilderness between Egypt and the Promised Land. A journey that should have taken weeks takes a generation. The reason is simple: when scouts returned from Canaan and reported fortified cities and powerful inhabitants, the people panicked.
+
+> Then all the congregation raised a loud cry, and the people wept that night. And all the people of Israel grumbled against Moses and against Aaron... "Would that we had died in the land of Egypt!"
+— [Numbers 14:1-2 ESV][12]
+
+They wanted to go back to slavery. Let that sink in. They had seen the plagues. They had walked through a parted sea. They were eating food that appeared on the ground every morning. And when the next step required courage, they chose the chains they knew over the freedom they didn't.
+
+God's response: this generation will not enter the Promised Land. They will wander until the last of them dies, and their children — the ones who didn't choose fear — will be the ones who cross the Jordan.
+
+The wilderness is not punishment for the sake of punishment. It is the consequence of the choice. You chose fear over faith. You chose slavery over mission. That choice has a cost, and the cost is that you don't get to see it through. Your children will.
+
+Forty years of wandering. Forty years of manna, water from rocks, complaints, rebellion, and God's relentless patience. The wilderness is the proving ground — not where Israel proves itself worthy, but where God proves He won't quit.
+
+## Moses at the boundary
+
+After forty years, Israel reaches the edge of the Promised Land. And Moses — the man who faced Pharaoh, who climbed Sinai, who held an entire nation together for four decades — is told he will not cross.
+
+> And the LORD said to Moses and Aaron, "Because you did not believe in me, to uphold me as holy in the eyes of the people of Israel, therefore you shall not bring this assembly into the land that I have given them."
+— [Numbers 20:12 ESV][13]
+
+The offense seems minor. At Meribah, God told Moses to speak to a rock and water would flow. Instead, Moses struck the rock twice with his staff, in anger, in front of the people. The water came — but Moses took credit for the miracle and displayed frustration instead of trust.
+
+This feels disproportionate. A lifetime of faithful service, and one moment of anger at a rock costs you everything?
+
+But that's the point. The standard is the standard. It doesn't bend for seniority. Moses — the greatest leader in the Old Testament — is held to the same accountability as the people he led. No one gets a pass. Not Abraham, who lied about his wife. Not Moses, who struck the rock. The Bible does not protect its heroes from the consequences of their choices.
+
+Moses sees the Promised Land from Mount Nebo. He dies there. Joshua leads the people across the Jordan.
+
+## What this means for the story
+
+This chapter covers the most concentrated period of divine intervention in the entire Bible. Plagues, a parted sea, a mountain on fire, food from heaven, water from stone. God is present in ways that are unmistakable, undeniable, and — critically — temporary.
+
+Because none of it was enough.
+
+The plagues didn't make Pharaoh a believer. The parted sea didn't prevent the golden calf. The manna didn't stop the grumbling. The Law didn't make Israel righteous. Forty years of miracles didn't produce a generation willing to enter Canaan without fear.
+
+This is what the Law teaches, not through its content but through Israel's failure to keep it: external rules and spectacular signs cannot change what is inside a person. You can show someone the path, part the ocean in front of them, feed them from the sky — and they will still choose the golden calf if that's what their heart wants.
+
+The Law was never the solution. It was the setup. It was the four-hundred-year demonstration that humanity needs something the Law cannot provide. That something is still a few chapters away.
+
+## Questions to sit with
+
+* God gave the Law knowing people would break it. What does that tell you about the purpose of rules — in religion, and in your own life?
+* The Israelites wanted to go back to slavery rather than face the unknown. Where in your life have you chosen a familiar cage over an uncertain freedom?
+* Moses served faithfully for forty years and was denied entry to the Promised Land for one act of disobedience. Is that fair? Does "fair" matter?
+
+[1]: https://www.esv.org/Exodus+1/
+[2]: https://www.esv.org/Exodus+3/
+[3]: https://www.esv.org/Exodus+3:11/
+[4]: https://www.esv.org/Exodus+4:1/
+[5]: https://www.esv.org/Exodus+4:10/
+[6]: https://www.esv.org/Exodus+12/
+[7]: https://www.esv.org/Exodus+14/
+[8]: https://www.esv.org/Romans+3:20/
+[9]: https://www.esv.org/Leviticus+19:34/
+[10]: https://www.esv.org/Galatians+3/
+[11]: https://www.esv.org/Exodus+32/
+[12]: https://www.esv.org/Numbers+14/
+[13]: https://www.esv.org/Numbers+20/

--- a/manuscript/ch08-moses-and-the-law.md
+++ b/manuscript/ch08-moses-and-the-law.md
@@ -1,7 +1,7 @@
 # Hour 8: Moses and the Law
 
 Q: Why did God give rules He knew people would break?
-A: Because you can't choose the mission if no one has shown you what the mission looks like.
+A: Because early humanity didn't know how to conduct themselves. Rules are how you teach children — and humanity was a child. You internalize the rules, you grow up, and eventually you don't need someone handing them to you anymore. Humanity is in adulthood now.
 
 ## Commentary
 
@@ -68,7 +68,7 @@ Because the Law is not the cure. The Law is the diagnosis.
 
 Without the Law, sin is vague. It's "choosing self over mission" — true, but abstract. The Law makes it specific. Don't murder. Don't steal. Don't covet what belongs to someone else. Don't lie under oath. Honor your parents. Rest one day in seven. Love the foreigner living among you as yourself ([Leviticus 19:34][9]).
 
-The Law takes the mission and translates it into behavior. It gives Israel — and through them, eventually, the world — a concrete picture of what faithful living looks like. Not because following every rule earns God's approval, but because you can't choose the right path if no one has shown you what the path looks like.
+The Law takes the mission and translates it into behavior. It gives Israel — and through them, eventually, the world — a concrete picture of what faithful living looks like. Think of it the way a parent raises a child: you start with explicit rules because the child doesn't yet have the judgment to navigate on their own. The rules aren't the goal. Internalization is the goal. The child who grows up and does the right thing without being told — that's the success case. The Law is parenting on a civilizational scale.
 
 Paul understood this:
 

--- a/manuscript/ch08-moses-and-the-law.md
+++ b/manuscript/ch08-moses-and-the-law.md
@@ -75,7 +75,7 @@ Paul understood this:
 > Is the law then contrary to the promises of God? Certainly not! For if a law had been given that could give life, then righteousness would indeed be by the law. But the Scripture imprisoned everything under sin, so that the promise by faith in Jesus Christ might be given to those who believe.
 — [Galatians 3:21-22 ESV][10]
 
-The Law was never meant to save anyone. It was meant to show you why you need saving. It holds up a mirror and says: here is the standard, and here is how far you fall short. That gap — between what the Law demands and what you can deliver — is exactly where grace enters the story. But grace is a few chapters away. Israel had to live under the Law first, long enough to learn the lesson.
+The Law was never meant to save anyone. It was meant to show you why you need saving. It holds up a mirror and says: here is the standard, and here is how far you fall short. That gap — between what the Law demands and what you can deliver — is exactly where grace enters the story. But grace is a few chapters away. Humanity wasn't ready for it yet. You don't hand a child the keys and say "figure it out." You give them rules, let them fail, and wait until they're mature enough to understand why the rules mattered in the first place.
 
 ## The golden calf
 
@@ -134,7 +134,9 @@ The plagues didn't make Pharaoh a believer. The parted sea didn't prevent the go
 
 This is what the Law teaches, not through its content but through Israel's failure to keep it: external rules and spectacular signs cannot change what is inside a person. You can show someone the path, part the ocean in front of them, feed them from the sky — and they will still choose the golden calf if that's what their heart wants.
 
-The Law was never the solution. It was the setup. It was the four-hundred-year demonstration that humanity needs something the Law cannot provide. That something is still a few chapters away.
+Return to the analogy from earlier in this chapter. The Law is how a parent raises a child — explicit rules, clear consequences, constant supervision. The wilderness is adolescence — testing boundaries, failing, learning the hard way that the rules existed for a reason. Every rebellion, every golden calf, every "let's go back to Egypt" is the growing pain of a species that hasn't matured enough to carry the mission on its own.
+
+The Law was never the solution. It was the setup. It was the necessary stage of development — the long, painful education that would eventually make adulthood possible. And when adulthood arrives, it will have a name. That's still a few chapters away.
 
 ## Questions to sit with
 


### PR DESCRIPTION
## Summary

Second chapter of Part II (The Story). Covers the full Exodus arc from Egyptian slavery to the boundary of the Promised Land:

- **Bridge from Abraham** — Joseph, descent into Egypt, four centuries of slavery
- **Moses's call** — burning bush, reluctance, obedience despite inadequacy
- **The Exodus** — ten plagues, Passover (foreshadowing Christ's crucifixion timing), Red Sea
- **The Law at Sinai** — Ten Commandments + hundreds of laws; the Law as diagnosis, not cure ("through the law comes knowledge of sin")
- **The golden calf** — same pattern as Ch 7 (provide → rebel → consequences → try again), six weeks after the Red Sea
- **The wilderness** — forty years because a generation chose familiar slavery over uncertain freedom
- **Moses denied entry** — struck the rock instead of speaking to it; the standard doesn't bend for seniority

Key theological thread: the Law was never the solution — it was the setup. A four-hundred-year demonstration that external rules and spectacular signs cannot change what is inside a person. That "something else" is still a few chapters away.

## Sharp edges to watch for
- The "why doesn't God intervene today?" question is addressed head-on via tenet #2, but explicitly acknowledged as unsatisfying: "That might not satisfy you. It shouldn't be easy."
- Moses's punishment at Meribah is presented as severe but consistent — "the standard is the standard" — without trying to soften it
- The golden calf is framed as the same pattern from Ch 7 (Noah post-flood, now Israel post-Exodus) to build the argument that miracles don't fix the internal problem

## Structure
- Q&A opener, consistent with Part I and Ch 7 format
- 13 ESV scripture references with linked footnotes
- "Questions to sit with" closer
- ~157 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)