### PR TITLE
Draft Chapter 9: The Prophets

### DIFF
--- a/manuscript/ch09-the-prophets.md
+++ b/manuscript/ch09-the-prophets.md
@@ -20,12 +20,14 @@ God tells Samuel plainly: asking for a king is a rejection of God's leadership. 
 
 Saul is the first king. He starts well and ends in paranoia, jealousy, and disobedience. David follows — the shepherd boy, the giant-killer, the poet who wrote the Psalms. David is called "a man after God's own heart" ([1 Samuel 13:14][2]), and he is also an adulterer and a murderer. He saw Bathsheba, took her, and when she became pregnant, he arranged for her husband Uriah to be killed in battle ([2 Samuel 11][3]).
 
-The Bible does not flinch from this. The greatest king in Israel's history — the one from whose line Jesus would come — committed acts that should disqualify him from any position of moral authority. And the prophet Nathan walked into the palace and told him so.
+The Bible does not flinch from this. The greatest king in Israel's history — the one from whose line Jesus would come — committed acts that should disqualify him from any position of moral authority. And the prophet Nathan walked into the palace and made David condemn himself.
+
+Nathan didn't accuse David directly. He told him a story: a rich man with enormous flocks stole the one beloved lamb of a poor man — the only thing the poor man had, a lamb he'd raised like a daughter. David was furious. "The man who has done this deserves to die!" ([2 Samuel 12:5][4a]). Then Nathan delivered the line that echoes through every chapter of prophetic literature:
 
 > Nathan said to David, "You are the man!"
 — [2 Samuel 12:7 ESV][4]
 
-This is what prophets do. They tell the truth to power. Not predictions about the future — though some of their messages include that. Prophecy in the biblical sense is not fortune-telling. It is truth-telling. A prophet is someone who sees what everyone else sees and says what no one else will say.
+David had pronounced his own sentence. That is what prophets do. They tell the truth to power — and sometimes they make power tell the truth to itself. Not predictions about the future — though some of their messages include that. Prophecy in the biblical sense is not fortune-telling. It is truth-telling. A prophet is someone who sees what everyone else sees and says what no one else will say.
 
 Solomon follows David. He builds the Temple. He accumulates wealth, wives, and wisdom. And by the end of his reign, his heart has turned to other gods ([1 Kings 11:4][5]). The pattern holds. Even the wisest person in Israel's history couldn't sustain faithfulness across a lifetime.
 
@@ -59,7 +61,7 @@ Isaiah saw further than any of them. In the middle of warnings about judgment, h
 > But he was pierced for our transgressions; he was crushed for our iniquities; upon him was the chastisement that brought us peace, and with his wounds we are healed.
 — [Isaiah 53:5 ESV][9]
 
-Isaiah wrote this seven hundred years before Jesus. Whether you read it as divine revelation or as a poet articulating a hope so deep it became its own kind of prophecy, the words are there. Pierced. Crushed. Healed. The suffering servant — the one who would carry the weight that no amount of Law-keeping could lift.
+Isaiah wrote this seven hundred years before Jesus. Whether you read it as divine revelation or as a poet articulating a hope so deep it became its own kind of prophecy, the words are there. Pierced. Crushed. Healed. The suffering servant — not a workaround for human failure, but the ultimate demonstration of what faithfulness looks like when it costs everything. The final, blazing message from God: *this is who you are capable of becoming.*
 
 ## The exile
 
@@ -121,7 +123,8 @@ The Old Testament ends in waiting. The prophets have spoken. The silence has beg
 [1]: https://www.esv.org/1+Samuel+8/
 [2]: https://www.esv.org/1+Samuel+13:14/
 [3]: https://www.esv.org/2+Samuel+11/
-[4]: https://www.esv.org/2+Samuel+12/
+[4]: https://www.esv.org/2+Samuel+12:7/
+[4a]: https://www.esv.org/2+Samuel+12:5/
 [5]: https://www.esv.org/1+Kings+11/
 [6]: https://www.esv.org/Amos+5/
 [7]: https://www.esv.org/Hosea+3/

--- a/manuscript/ch09-the-prophets.md
+++ b/manuscript/ch09-the-prophets.md
@@ -1,0 +1,132 @@
+# Hour 9: The Prophets
+
+Q: If God stopped intervening directly, how did He communicate with Israel?
+A: Through people who told the truth no one wanted to hear.
+
+## Commentary
+
+Hour 8 ended at the Jordan River. Joshua led a new generation into Canaan — the land God promised Abraham centuries earlier. The conquest was brutal, the settlement was messy, and for a few hundred years, Israel governed itself through judges — military and spiritual leaders who rose up in times of crisis, delivered the people, and then watched them slide back into the same patterns.
+
+The cycle should be familiar by now: God provides, Israel forgets, consequences follow, God raises someone up, Israel repents, and the wheel turns again. Judges is the book of that wheel spinning until the axle breaks.
+
+Then Israel asks for a king.
+
+## The kingdom
+
+> But the thing displeased Samuel when they said, "Give us a king to judge us." And Samuel prayed to the LORD. And the LORD said to Samuel, "Obey the voice of the people in all that they say to you, for they have not rejected you, but they have rejected me from being king over them."
+— [1 Samuel 8:6-7 ESV][1]
+
+God tells Samuel plainly: asking for a king is a rejection of God's leadership. But God doesn't stop them. This is the free will framework in action — humanity choosing its own path, and God allowing the choice even when it's the wrong one.
+
+Saul is the first king. He starts well and ends in paranoia, jealousy, and disobedience. David follows — the shepherd boy, the giant-killer, the poet who wrote the Psalms. David is called "a man after God's own heart" ([1 Samuel 13:14][2]), and he is also an adulterer and a murderer. He saw Bathsheba, took her, and when she became pregnant, he arranged for her husband Uriah to be killed in battle ([2 Samuel 11][3]).
+
+The Bible does not flinch from this. The greatest king in Israel's history — the one from whose line Jesus would come — committed acts that should disqualify him from any position of moral authority. And the prophet Nathan walked into the palace and told him so.
+
+> Nathan said to David, "You are the man!"
+— [2 Samuel 12:7 ESV][4]
+
+This is what prophets do. They tell the truth to power. Not predictions about the future — though some of their messages include that. Prophecy in the biblical sense is not fortune-telling. It is truth-telling. A prophet is someone who sees what everyone else sees and says what no one else will say.
+
+Solomon follows David. He builds the Temple. He accumulates wealth, wives, and wisdom. And by the end of his reign, his heart has turned to other gods ([1 Kings 11:4][5]). The pattern holds. Even the wisest person in Israel's history couldn't sustain faithfulness across a lifetime.
+
+After Solomon, the kingdom splits. Israel in the north, Judah in the south. Two nations, both carrying pieces of the covenant, both failing it in their own ways. This is where the prophets become the center of the story.
+
+## What the prophets actually were
+
+Forget the image of a mystic with a crystal ball. Biblical prophets were uncomfortable people delivering uncomfortable messages to people who didn't want to hear them. They were farmers, priests, shepherds, and outsiders. They interrupted courts, confronted kings, and predicted consequences that came true — not because they had magical foresight, but because they understood what happens when a society abandons justice.
+
+Amos was a shepherd and a fig farmer. He walked into the wealthy northern kingdom and said this:
+
+> I hate, I despise your feasts, and I take no delight in your solemn assemblies. Even though you offer me your burnt offerings and grain offerings, I will not accept them... But let justice roll down like waters, and righteousness like an ever-flowing stream.
+— [Amos 5:21-24 ESV][6]
+
+God doesn't want their worship. Not because worship is wrong, but because worship without justice is performance. Israel had the Temple, the sacrifices, the feasts, the rituals — all the external markers of faithfulness — and none of the substance. They were keeping the letter of the Law while gutting its purpose.
+
+This is the maturation metaphor from Hour 8 taken further. A child who follows the rules to avoid punishment but doesn't understand why the rules exist has not internalized them. Israel was performing religion without becoming the kind of people the religion was designed to produce.
+
+Hosea's message was even more visceral. God told him to marry a woman who would be unfaithful to him — as a living metaphor for Israel's relationship with God.
+
+> And the LORD said to me, "Go again, love a woman who is loved by another man and is an adulteress, even as the LORD loves the children of Israel, though they turn to other gods."
+— [Hosea 3:1 ESV][7]
+
+The prophets didn't just deliver messages. They embodied them. Their lives were the sermon.
+
+Isaiah saw further than any of them. In the middle of warnings about judgment, he wrote passages that would not make sense for centuries:
+
+> Therefore the Lord himself will give you a sign. Behold, the virgin shall conceive and bear a son, and shall call his name Immanuel.
+— [Isaiah 7:14 ESV][8]
+
+> But he was pierced for our transgressions; he was crushed for our iniquities; upon him was the chastisement that brought us peace, and with his wounds we are healed.
+— [Isaiah 53:5 ESV][9]
+
+Isaiah wrote this seven hundred years before Jesus. Whether you read it as divine revelation or as a poet articulating a hope so deep it became its own kind of prophecy, the words are there. Pierced. Crushed. Healed. The suffering servant — the one who would carry the weight that no amount of Law-keeping could lift.
+
+## The exile
+
+The prophets warned. Israel didn't listen. And the consequences the prophets described came to pass — not as supernatural punishment, but as the natural result of a nation that had abandoned the things that held it together.
+
+The northern kingdom fell to Assyria in 722 BC. The ten tribes were scattered and effectively disappeared from history. The southern kingdom, Judah, lasted longer but not by much. In 586 BC, Babylon conquered Jerusalem, destroyed the Temple Solomon had built, and carried the people into exile.
+
+> By the waters of Babylon, there we sat down and wept, when we remembered Zion.
+— [Psalm 137:1 ESV][10]
+
+Everything was gone. The Temple, the city, the land, the kingdom. Everything God had promised Abraham — descendants, a nation, a land — appeared to be lost.
+
+Jeremiah, who had warned about this for decades and been imprisoned for it, wrote to the exiles:
+
+> For I know the plans I have for you, declares the LORD, plans for welfare and not for evil, to give you a future and a hope.
+— [Jeremiah 29:11 ESV][11]
+
+This verse is popular on greeting cards and graduation speeches. In context, it was written to people who had lost everything. Their country was destroyed, their Temple was ash, and they were prisoners in a foreign land. Jeremiah is not offering comfort. He is offering a lifeline: the story is not over. The mission continues. Even here. Even now.
+
+## Special treatment then vs. expectations now
+
+This is the chapter where we need to address the elephant in the room.
+
+From Genesis through the prophets — from the burning bush to the parting of the Red Sea to a pillar of fire by night to manna from heaven to voices thundering from mountains — God's presence in the Old Testament is dramatic, unmistakable, and direct. God speaks. God acts. God shows up in ways that leave no room for doubt.
+
+No one alive today should expect any of that.
+
+This is not a contradiction. It is a transition. The Old Testament records a specific phase of God's interaction with humanity — the phase where God was building a people, establishing a covenant, giving the Law, and setting the stage for Christ. That phase required direct intervention. Humanity was in childhood, and children need a parent who is visibly, actively present.
+
+The prophets are the hinge. They stand between the era of dramatic intervention and the era of human responsibility. Their role was to say: you have the Law, you have the covenant, you have centuries of evidence about what happens when you follow God and what happens when you don't. Act on what you know.
+
+When the prophets fell silent — and there is roughly four hundred years of silence between the last prophet (Malachi) and John the Baptist — that silence was not abandonment. It was the pause between childhood and adulthood. The rules had been given. The lessons had been taught. The consequences had been demonstrated. Now it was time to see whether Israel — and through them, humanity — could carry the mission forward.
+
+They couldn't. Not without one more intervention — the final one. But that intervention would look nothing like a parted sea or a mountain on fire. It would look like a baby born in a stable in an occupied country.
+
+That's the next chapter.
+
+## What this means for the story
+
+The prophets reveal the heart of the Old Testament's failure — and the word "failure" is deliberate. Israel failed. The kingdom failed. The Law, as a mechanism for producing faithful people, failed. Not because the Law was wrong, but because external structure cannot transform internal character.
+
+The prophets knew this. That's why Jeremiah wrote about a new covenant:
+
+> I will put my law within them, and I will write it on their hearts.
+— [Jeremiah 31:33 ESV][12]
+
+Not on stone tablets. Not in scrolls. On hearts. The prophets saw that the entire system — Law, Temple, sacrifice, kingdom — was pointing beyond itself to something that hadn't arrived yet. The rules were the childhood phase. The prophets were the voice saying: you're about to grow up, and growing up means the rules move from the tablet to the heart, from the outside to the inside.
+
+The exile stripped away everything external. No Temple, no land, no kingdom. What survived was faith — the choice to trust God when every visible sign of God's presence had been destroyed. That is the test. Not whether you can follow rules when the Temple is standing and the priests are offering sacrifices. Whether you can hold onto the mission when everything that made it feel real is gone.
+
+The Old Testament ends in waiting. The prophets have spoken. The silence has begun. And somewhere in that silence, the story pivots from everything God did to the one thing God would do next.
+
+## Questions to sit with
+
+* The prophets told truths that made them unpopular, imprisoned, and sometimes killed. When was the last time you said something true that cost you something?
+* Israel kept the rituals of faith while abandoning its substance. Where in your own life do you perform faithfulness without practicing it?
+* Four hundred years of prophetic silence separated the Old Testament from the New. If God went silent in your life for that long, would your faith survive?
+
+[1]: https://www.esv.org/1+Samuel+8/
+[2]: https://www.esv.org/1+Samuel+13:14/
+[3]: https://www.esv.org/2+Samuel+11/
+[4]: https://www.esv.org/2+Samuel+12/
+[5]: https://www.esv.org/1+Kings+11/
+[6]: https://www.esv.org/Amos+5/
+[7]: https://www.esv.org/Hosea+3/
+[8]: https://www.esv.org/Isaiah+7/
+[9]: https://www.esv.org/Isaiah+53/
+[10]: https://www.esv.org/Psalm+137/
+[11]: https://www.esv.org/Jeremiah+29/
+[12]: https://www.esv.org/Jeremiah+31/


### PR DESCRIPTION
## Summary

Third and final OT chapter of Part II (The Story). Covers the entire arc from Joshua's entry into Canaan through the four hundred years of prophetic silence before Christ:

- **The kingdom** — Israel asks for a king (rejection of God's leadership, but God allows it). Saul, David, Solomon — each starts well, each fails. David as both "man after God's own heart" and adulterer/murderer. Nathan's confrontation.
- **The prophets as truth-tellers** — Not fortune-tellers. Amos (justice over ritual), Hosea (his marriage as living metaphor), Isaiah (suffering servant 700 years before Christ), Jeremiah (new covenant written on hearts).
- **The exile** — Assyria takes the north (722 BC), Babylon destroys Jerusalem and the Temple (586 BC). Everything external is stripped away. What survives is faith alone.
- **Special treatment then vs. expectations now** — The cross-cutting theme flagged in the outline. Addressed head-on: the OT phase was childhood, requiring visible parenting. The prophets are the hinge. The silence is the pause between childhood and adulthood.
- **The silence** — Four hundred years between Malachi and John the Baptist. Not abandonment but transition.

## Sharp edges to watch for
- David's sins (Bathsheba, Uriah) are presented without softening — "acts that should disqualify him from any position of moral authority"
- The word "failure" is used deliberately for Israel, the kingdom, and the Law-as-mechanism
- The "special treatment" section directly states "No one alive today should expect any of that" — this is the tenet #2/3 nexus, stated as plainly as possible
- Jeremiah 29:11 is re-contextualized: not a comfort verse, but a lifeline to people who had lost everything

## Structure
- Q&A opener, consistent with Part I/II format
- 12 ESV scripture references with linked footnotes
- Continues the maturation metaphor from Ch 8 (childhood → prophets as the voice saying "you're about to grow up")
- "Questions to sit with" closer
- ~132 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)