### PR TITLE
Draft Chapter 14: Prayer

### DIFF
--- a/manuscript/ch14-prayer.md
+++ b/manuscript/ch14-prayer.md
@@ -5,11 +5,11 @@ A: Define "work." If you mean does God grant requests — read on. If you mean d
 
 ## Commentary
 
-Prayer is the most misunderstood practice in Christianity. Not because it's complicated — it's not — but because nearly everything the modern church teaches about it is built on an assumption this book rejects.
+Prayer is the most misunderstood practice in Christianity. Not because it's complicated — it's not — but because nearly everything the modern church teaches about it is built on a false assumption.
 
 The assumption: God is listening and might intervene.
 
-The framework of this book: God gave humanity everything we need — the example of Jesus, the record of Scripture, the capacity to reason — and stepped back. He is not adjusting outcomes. He is not granting requests. He is not running a cosmic customer service line with hold music and a callback option.
+But here is the reality: God gave humanity everything we need — the example of Jesus, the record of Scripture, the capacity to reason — and stepped back. He is not adjusting outcomes. He is not granting requests. He is not running a cosmic customer service line with hold music and a callback option.
 
 So what is prayer?
 
@@ -68,7 +68,7 @@ God didn't answer. The cup did not pass. Jesus went to the cross.
 
 This is the central prayer of Christianity, and it was not granted. If you build your understanding of prayer on the idea that God hears and responds to requests, you have to explain why he didn't respond to this one. Why would God ignore the prayer of the person who carried the mission most faithfully?
 
-The answer, in the framework of this book: God wasn't ignoring the prayer. The prayer was never about changing the outcome. The prayer was about Jesus being honest about what he faced, naming his fear, and then choosing the mission anyway.
+The answer: God wasn't ignoring the prayer. The prayer was never about changing the outcome. The prayer was about Jesus being honest about what he faced, naming his fear, and then choosing the mission anyway.
 
 "Not my will, but yours, be done." That's not resignation. That's realignment. Jesus walked into Gethsemane afraid. He walked out resolved. The prayer didn't change what happened next. It changed whether he was ready for it.
 
@@ -89,7 +89,7 @@ Prayer changes you. Specifically, it does three things:
 
 **It recalibrates your priorities.** The Lord's Prayer asks for daily bread — enough for today. Not enough for retirement. Not enough for the vacation house. Enough. When you pray for enough, you're confronting the gap between what you need and what you're chasing. Most of what consumes your energy — the promotion, the upgrade, the next milestone — has nothing to do with the mission. Prayer is the practice of remembering that.
 
-**It builds the muscle for hard choices.** Gethsemane wasn't the first time Jesus prayed. Luke records that he "would withdraw to desolate places and pray" ([Luke 5:16][4]) throughout his ministry. He prayed before choosing the twelve disciples ([Luke 6:12][5]). He prayed before feeding the five thousand ([Matthew 14:19][6]). The practice wasn't magic. It was preparation. By the time the hardest night of his life arrived, the habit of stopping, being honest, and realigning was already built. Gethsemane worked because every prayer before it had built the capacity to say, "Not my will, but yours."
+**It builds the muscle for hard choices.** Gethsemane wasn't the first time Jesus prayed. Luke records that Jesus "would withdraw to desolate places and pray" ([Luke 5:16][4]) throughout his ministry. He prayed before choosing the twelve disciples ([Luke 6:12][5]). He prayed before feeding the five thousand ([Matthew 14:19][6]). The practice wasn't magic. It was preparation. By the time the hardest night of his life arrived, the habit of stopping, being honest, and realigning was already built. Gethsemane worked because every prayer before it had built the capacity to say, "Not my will, but yours."
 
 ## What prayer is not
 

--- a/manuscript/ch14-prayer.md
+++ b/manuscript/ch14-prayer.md
@@ -1,0 +1,132 @@
+# Hour 14: Prayer
+
+Q: Does prayer work?
+A: Define "work." If you mean does God grant requests — read on. If you mean does prayer change you — it can. And that's the point.
+
+## Commentary
+
+Prayer is the most misunderstood practice in Christianity. Not because it's complicated — it's not — but because nearly everything the modern church teaches about it is built on an assumption this book rejects.
+
+The assumption: God is listening and might intervene.
+
+The framework of this book: God gave humanity everything we need — the example of Jesus, the record of Scripture, the capacity to reason — and stepped back. He is not adjusting outcomes. He is not granting requests. He is not running a cosmic customer service line with hold music and a callback option.
+
+So what is prayer?
+
+Prayer is how you stop, tell the truth, and remember what matters. It is the practice of orientation. Not asking God to change your circumstances, but examining whether you are living as though the mission matters. That may sound like a downgrade. It's not. It's the only version of prayer that has ever actually worked.
+
+## Jesus on prayer
+
+Jesus talked about prayer more than almost any other practice. And the first thing he said about it was a warning.
+
+> "And when you pray, you must not be like the hypocrites. For they love to stand and pray in the synagogues and at the street corners, that they may be seen by others. Truly, I say to you, they have received their reward."
+— [Matthew 6:5 ESV][1]
+
+Public prayer is performance. It's not for God — it's for the audience. Jesus is direct: if you're praying so people can see you praying, you've already gotten everything you're going to get out of it. Applause. Social standing. The reputation of being devout. That's your reward. Don't expect anything more.
+
+> "But when you pray, go into your room and shut the door and pray to your Father who is in secret."
+— [Matthew 6:6 ESV][1]
+
+Shut the door. No audience. No one to perform for. Just you and the honest accounting of your own life. That's where prayer starts.
+
+Then he said something that should stop every long-winded prayer in its tracks:
+
+> "And when you pray, do not heap up empty phrases as the Gentiles do, for they think that they will be heard for their many words. Do not be like them, for your Father knows what you need before you ask him."
+— [Matthew 6:7-8 ESV][1]
+
+Read that last line again. God knows what you need before you ask. So why pray?
+
+Not to inform God. Not to persuade God. Not to accumulate enough words that God finally pays attention. You pray because *you* need the practice of stopping and being honest.
+
+## The Lord's Prayer
+
+Immediately after telling people to stop talking so much, Jesus gave a model:
+
+> "Our Father in heaven, hallowed be your name. Your kingdom come, your will be done, on earth as it is in heaven. Give us this day our daily bread, and forgive us our debts, as we also have forgiven our debtors. And lead us not into temptation, but deliver us from evil."
+— [Matthew 6:9-13 ESV][1]
+
+The entire prayer takes fifteen seconds. That's not an accident.
+
+Look at what it contains. Acknowledgment of God. Alignment with the mission ("your will be done, on earth as it is in heaven"). A request for enough — not wealth, not success, not healing, but bread for today. An honest reckoning with your own failures and your willingness to forgive others. And a plea for strength against temptation.
+
+Look at what it doesn't contain. No request for personal success. No request for God to fix a situation. No request for victory over enemies. No health and wealth. No "bless this food." No "watch over my family." No specific outcomes at all.
+
+The Lord's Prayer is a discipline of alignment. You start by remembering who God is. You affirm the mission. You ask for enough to keep going. You examine your own debts — what you owe and what you're owed — and commit to forgiving both. You ask for the strength not to quit.
+
+That's it. That's the model. Everything else is commentary.
+
+## The prayer God didn't answer
+
+The most revealing prayer in the Bible is the one Jesus prayed the night before he died.
+
+> And going a little farther he fell on his face and prayed, saying, "My Father, if it be possible, let this cup pass from me; nevertheless, not my will, but yours, be done."
+— [Matthew 26:39 ESV][2]
+
+Jesus asked to be spared. He didn't want to die. He wasn't stoic about it — Matthew says he was "sorrowful, even to death" ([Matthew 26:38][2]). He brought Peter, James, and John with him to Gethsemane because he needed people close. He fell on his face. He asked three times.
+
+God didn't answer. The cup did not pass. Jesus went to the cross.
+
+This is the central prayer of Christianity, and it was not granted. If you build your understanding of prayer on the idea that God hears and responds to requests, you have to explain why he didn't respond to this one. Why would God ignore the prayer of the person who carried the mission most faithfully?
+
+The answer, in the framework of this book: God wasn't ignoring the prayer. The prayer was never about changing the outcome. The prayer was about Jesus being honest about what he faced, naming his fear, and then choosing the mission anyway.
+
+"Not my will, but yours, be done." That's not resignation. That's realignment. Jesus walked into Gethsemane afraid. He walked out resolved. The prayer didn't change what happened next. It changed whether he was ready for it.
+
+That is what prayer does.
+
+## What prayer actually changes
+
+If prayer doesn't change outcomes, what's the point?
+
+Prayer changes you. Specifically, it does three things:
+
+**It forces honesty.** You can lie to everyone else. You can maintain the image — the competent parent, the successful professional, the faithful church member. But if you actually shut the door and sit with yourself, the pretense runs out of oxygen. David's prayer in Psalm 51, after Nathan confronted him about Bathsheba, starts here:
+
+> "Have mercy on me, O God, according to your steadfast love; according to your abundant mercy blot out my transgressions. For I know my transgressions, and my sin is ever before me."
+— [Psalm 51:1-3 ESV][3]
+
+"I know my transgressions." Not "I didn't realize." Not "circumstances led me to." I know. Prayer is the practice of admitting what you already know but haven't said out loud.
+
+**It recalibrates your priorities.** The Lord's Prayer asks for daily bread — enough for today. Not enough for retirement. Not enough for the vacation house. Enough. When you pray for enough, you're confronting the gap between what you need and what you're chasing. Most of what consumes your energy — the promotion, the upgrade, the next milestone — has nothing to do with the mission. Prayer is the practice of remembering that.
+
+**It builds the muscle for hard choices.** Gethsemane wasn't the first time Jesus prayed. Luke records that he "would withdraw to desolate places and pray" ([Luke 5:16][4]) throughout his ministry. He prayed before choosing the twelve disciples ([Luke 6:12][5]). He prayed before feeding the five thousand ([Matthew 14:19][6]). The practice wasn't magic. It was preparation. By the time the hardest night of his life arrived, the habit of stopping, being honest, and realigning was already built. Gethsemane worked because every prayer before it had built the capacity to say, "Not my will, but yours."
+
+## What prayer is not
+
+Prayer is not a transaction. "God, if you heal my mother, I'll go to church every Sunday" is not prayer. It's a negotiation, and you don't have leverage.
+
+Prayer is not a formula. Repeating specific words in a specific order does not produce results. The rosary is not a spell. "In Jesus's name" is not a password. The early church prayed in their own words, from their own circumstances, about their own failures. You should do the same.
+
+Prayer is not proof of faith. Some of the most faithful people in the Bible didn't pray elaborate prayers. They acted. The Good Samaritan didn't stop to pray before helping the wounded man — he just helped. Martha, while her sister Mary sat at Jesus's feet, was doing the practical work of hospitality ([Luke 10:38-42][7]). Jesus gently corrected her anxiety, not her service. Action and prayer are both expressions of orientation. Neither replaces the other.
+
+Prayer is not a substitute for effort. "I'll pray about it" is often code for "I'll do nothing about it." If you can act, act. If you can help, help. If you can change, change. Pray when you need to be honest with yourself about why you aren't doing those things.
+
+## How to pray
+
+Jesus kept it simple. So will this chapter.
+
+Go somewhere quiet. Shut the door. Don't perform. Don't use words you wouldn't use in conversation. Don't try to sound holy.
+
+Start by telling the truth. What happened today? Where did you fall short? What are you afraid of? What are you holding onto that you shouldn't be? This is not confession in the institutional sense — no priest, no penance, no absolution. This is you, being honest with yourself in the only context where honesty costs nothing.
+
+Then remember the mission. Not in the abstract — specifically. Who needed you today and didn't get you? Where did you choose yourself over your neighbor? Where did you choose comfort over courage? The two commandments from Hour 13 — love God, love your neighbor — are the measuring stick. Hold yourself against it.
+
+Then ask for enough. Enough strength for tomorrow. Enough patience. Enough courage. Not enough to be comfortable — enough to keep going.
+
+Then forgive. Whoever wronged you, whatever is sitting in your chest like a stone — name it, and let it go. Not because they deserve it. Because carrying it is pulling you away from the mission. Hour 18 will dig deeper into this, but it starts here, in the quiet, with no audience.
+
+Then get up. And do the thing that prayer prepared you to do.
+
+## Questions to sit with
+
+* When was the last time you prayed and were genuinely honest — not performing, not reciting, but telling the truth about where you are?
+* Jesus prayed to be spared and wasn't. Has your understanding of prayer been built on the expectation that God will give you what you ask for? What happens to your faith if he doesn't?
+* What would change in your daily life if you spent two minutes each morning in honest self-examination instead of scrolling your phone?
+
+[1]: https://www.esv.org/Matthew+6/
+[2]: https://www.esv.org/Matthew+26/
+[3]: https://www.esv.org/Psalm+51/
+[4]: https://www.esv.org/Luke+5/
+[5]: https://www.esv.org/Luke+6/
+[6]: https://www.esv.org/Matthew+14/
+[7]: https://www.esv.org/Luke+10/


### PR DESCRIPTION
## Summary
- First practical chapter after Ch 13's framework — prayer as orientation, not petition
- Built around Gethsemane: Jesus asked to be spared, wasn't, went to the cross anyway. The prayer changed him, not the outcome
- Lord's Prayer analyzed as a 15-second discipline of alignment, not a formula
- "What prayer is not" section addresses transactions, formulas, performance
- Practical "how to pray" section: honesty → mission check → ask for enough → forgive → act
- 7 ESV references, 132 lines
- Consistent with Tenet 3 (God is hands-off) — no interventionist framing of prayer

## Test plan
- [ ] Voice check — direct, no hedging, consistent with Ch 13 and Ch 16
- [ ] Theology check — no petition framing, no "God answers prayers," consistent with core tenets
- [ ] Scripture accuracy — all ESV references verified
- [ ] Connects to Ch 13 (love/orientation), sets up Ch 18 (forgiveness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)