### PR TITLE
Draft Chapter 17: Suffering

### DIFF
--- a/manuscript/ch17-suffering.md
+++ b/manuscript/ch17-suffering.md
@@ -1,7 +1,7 @@
 # Hour 17: Suffering
 
 Q: Why does God allow suffering?
-A: Because the test means nothing if it can't hurt.
+A: Pain gives the test meaning and makes the mission real.
 
 ## Commentary
 
@@ -30,7 +30,7 @@ Each has a kernel of truth and a mountain of problems.
 
 "God has a greater plan" is unfalsifiable — it explains everything and therefore nothing.
 
-"Satan causes suffering" contradicts the very dynamic described in Job, where Satan acts with God's explicit permission.
+"Satan causes suffering" raises a deeper problem: if Satan is the source of suffering, that challenges whether God can be trusted to triumph over evil at all. And in Job, Satan doesn't act independently — he acts with God's explicit permission, which puts the problem right back on God's desk.
 
 Here is what the first sixteen hours give us instead: God built a world with real consequences and real freedom, then stepped back. Suffering is not inflicted. It is not curated. It is not directed at specific people for specific reasons. It is what happens when a world runs on its own laws — physical laws, biological laws, and the consequences of free will.
 
@@ -115,7 +115,7 @@ None of this makes suffering good. Suffering is not a gift. It is not a blessing
 
 ## The hardest case
 
-Everything above meets its limit at one point: the suffering of the innocent. A child who has made no choices. An infant born into famine. A person with severe disabilities who never had the chance to carry the mission at all.
+None of those responses address the hardest case: the suffering of the innocent. A child who has made no choices. An infant born into famine. A person with severe disabilities who never had the chance to carry the mission at all.
 
 There is no theological answer that makes this okay. Any framework that claims to fully explain the suffering of the innocent is lying to you.
 

--- a/manuscript/ch17-suffering.md
+++ b/manuscript/ch17-suffering.md
@@ -59,16 +59,18 @@ God answers. And the answer is not what anyone expects.
 
 God doesn't explain. God doesn't apologize. God doesn't reveal a hidden purpose. God asks questions — four chapters of them. Have you commanded the morning? Can you bind the stars? Do you know when the mountain goats give birth? Can you draw out Leviathan with a fishhook?
 
-The point isn't cruelty. The point is scale. Job is demanding that the architect of the universe explain a specific blueprint decision to someone who can't read blueprints. God's response is not "I have a plan you can't see." It's "the universe is vastly more complex than your frame of reference allows you to evaluate."
+The point isn't a hidden plan. The point is that the universe doesn't revolve around Job's story. The mountain goats give birth whether Job is watching or not. Leviathan swims whether Job is in pain or not. God set creation in motion — vast, autonomous, operating by its own laws — and it keeps running. Job's suffering is not part of a design. It is not a chapter in a cosmic narrative written about him. It is what happens when a world that runs on its own terms intersects with one person's life.
+
+That sounds harsh. It's actually liberating. If your suffering is part of a plan, then God chose it for you — and you're back to explaining why a good God deliberately inflicts pain. But if the world simply operates and your suffering is not orchestrated, then it's not punishment. It's not a lesson. It's not targeted. It just *is*. And what you do with it is yours to decide.
 
 Job's response:
 
 > "I had heard of you by the hearing of the ear, but now my eye sees you; therefore I despise myself, and repent in dust and ashes."
 — [Job 42:5-6 ESV][3]
 
-Job doesn't get an explanation. He gets perspective. And the book ends with God rebuking the three friends — the ones who were sure suffering had a tidy moral cause — and vindicating Job, the one who had the honesty to say, "This isn't fair, and I don't understand."
+Job doesn't get an explanation. He gets something harder: the realization that he was demanding the universe answer to him, when the universe was never about him. And the book ends with God rebuking the three friends — the ones who were sure suffering had a tidy moral cause — and vindicating Job, the one who had the honesty to say, "This isn't fair, and I don't understand."
 
-That's the Bible's answer to suffering: you won't always understand. Your friends who think they understand are probably wrong. And the demand for a neat explanation is itself a failure to grasp the scale of what you're asking about.
+That's the Bible's answer to suffering: the universe is not a story about you. Your friends who think they can explain your pain are probably wrong. And the honest response — "I don't understand, but I won't walk away" — is more faithful than any tidy explanation.
 
 ## Jesus and suffering
 

--- a/manuscript/ch17-suffering.md
+++ b/manuscript/ch17-suffering.md
@@ -1,0 +1,138 @@
+# Hour 17: Suffering
+
+Q: Why does God allow suffering?
+A: Because the test means nothing if it can't hurt.
+
+## Commentary
+
+This is the question that breaks people. Not doubt about theology or confusion about doctrine — suffering. A child dies of cancer. An earthquake buries a city. A person lives a faithful life and gets repaid with tragedy. And someone says, "God has a plan."
+
+No. Stop saying that.
+
+"God has a plan" is the most destructive sentence in Christianity — not because it's theologically wrong (though it is), but because it's cruel. Telling a parent who just buried their child that God planned this is not comfort. It's violence dressed as theology.
+
+So let's be honest about suffering, even when honesty is harder than a platitude.
+
+## The problem, stated plainly
+
+If God is all-powerful and all-good, why does suffering exist? This is the Problem of Evil, and philosophers and theologians have wrestled with it for millennia. The standard answers go something like this:
+
+- God allows suffering to test our faith.
+- Suffering is the consequence of sin.
+- God has a greater plan we can't see.
+- Suffering is Satan's doing.
+
+Each has a kernel of truth and a mountain of problems.
+
+"Suffering tests faith" makes God a sadist who gives a child leukemia to see whether her parents will still pray.
+
+"Suffering is the consequence of sin" doesn't explain the tsunami that kills 230,000 people regardless of their moral character.
+
+"God has a greater plan" is unfalsifiable — it explains everything and therefore nothing.
+
+"Satan causes suffering" contradicts the very dynamic described in Job, where Satan acts with God's explicit permission.
+
+Here is what the first sixteen hours give us instead: God built a world with real consequences and real freedom, then stepped back. Suffering is not inflicted. It is not curated. It is not directed at specific people for specific reasons. It is what happens when a world runs on its own laws — physical laws, biological laws, and the consequences of free will.
+
+## Job
+
+If you want the Bible's own answer to suffering, skip the sermons and read Job.
+
+Job is a good man. The text is explicit about this — "blameless and upright, one who feared God and turned away from evil" ([Job 1:1][1]). He has wealth, health, children, and a reputation for integrity. He's done everything right.
+
+Then he loses everything. His livestock, his servants, his children — all taken in a single day. Then his health. He's sitting in ashes, scraping his skin with a piece of broken pottery, and his wife tells him to curse God and die ([Job 2:9][1]).
+
+Three friends show up. They spend seven days in silence — the last decent thing they do. Then they start talking, and every word makes it worse.
+
+Eliphaz: You must have sinned. God doesn't punish the innocent ([Job 4:7][1]).
+Bildad: Your children probably deserved it ([Job 8:4][1]).
+Zophar: You're getting less than you deserve ([Job 11:6][1]).
+
+This is the "suffering is the consequence of sin" argument, delivered by people who are sure of themselves and wrong about everything. If these arguments sound familiar, it's because they're still the default in most churches. Job's friends are the prototype for every well-meaning Christian who has ever said, "Maybe God is trying to teach you something."
+
+Job pushes back. He knows he hasn't done anything to warrant this. He demands an audience with God. He wants an explanation.
+
+God answers. And the answer is not what anyone expects.
+
+> "Where were you when I laid the foundation of the earth? Tell me, if you have understanding."
+— [Job 38:4 ESV][2]
+
+God doesn't explain. God doesn't apologize. God doesn't reveal a hidden purpose. God asks questions — four chapters of them. Have you commanded the morning? Can you bind the stars? Do you know when the mountain goats give birth? Can you draw out Leviathan with a fishhook?
+
+The point isn't cruelty. The point is scale. Job is demanding that the architect of the universe explain a specific blueprint decision to someone who can't read blueprints. God's response is not "I have a plan you can't see." It's "the universe is vastly more complex than your frame of reference allows you to evaluate."
+
+Job's response:
+
+> "I had heard of you by the hearing of the ear, but now my eye sees you; therefore I despise myself, and repent in dust and ashes."
+— [Job 42:5-6 ESV][3]
+
+Job doesn't get an explanation. He gets perspective. And the book ends with God rebuking the three friends — the ones who were sure suffering had a tidy moral cause — and vindicating Job, the one who had the honesty to say, "This isn't fair, and I don't understand."
+
+That's the Bible's answer to suffering: you won't always understand. Your friends who think they understand are probably wrong. And the demand for a neat explanation is itself a failure to grasp the scale of what you're asking about.
+
+## Jesus and suffering
+
+Jesus suffered. That matters.
+
+He wasn't shielded from hunger, exhaustion, grief, or fear. He wept when Lazarus died ([John 11:35][4]). He felt abandoned in Gethsemane. He cried out on the cross: "My God, my God, why have you forsaken me?" ([Matthew 27:46][5]).
+
+If Jesus — the person who carried the mission most faithfully — wasn't spared suffering, then suffering is not a sign that you've done something wrong. It's not God correcting you. It's not a consequence of insufficient faith. It's the terrain.
+
+The mission has always been carried through suffering, not around it. Abraham left everything familiar. Moses wandered for forty years. The prophets were mocked, imprisoned, killed. Jesus went to the cross. The early church was hunted. Faithfulness has never come with a guarantee of comfort.
+
+Suffering is not the opposite of the mission. Suffering is where the mission gets tested. Anyone can choose love, generosity, and justice when it costs nothing. The test only means something when it costs everything — and you choose the mission anyway.
+
+## What suffering is not
+
+**Suffering is not punishment.** If it were, the most faithful people would suffer least. They don't. The biblical pattern runs the other way — the more faithfully someone carries the mission, the more they tend to suffer. Jesus, the prophets, the early church. Suffering as punishment is Eliphaz's theology, and God explicitly condemned it.
+
+**Suffering is not a test administered by God.** God is not giving you cancer to see how you handle it. God stepped back. The world runs on its own laws. Cells mutate. Tectonic plates shift. People make choices that harm other people. These are not divine interventions — they are the mechanics of a world that operates on its own terms.
+
+**Suffering is not "God's plan."** This is the platitude that needs to die. When a child is born with a terminal illness, God did not plan that. When a genocide wipes out a people, God did not orchestrate it for a greater good. To claim God planned these things is to make God the author of the very evil the mission exists to overcome.
+
+**Suffering does not always have a reason.** Sometimes a hurricane destroys a city because warm water and atmospheric pressure produce hurricanes. Sometimes a good person gets sick because biology doesn't check your moral record. The insistence that every instance of suffering must have a divine reason behind it is not faith — it's the refusal to sit with uncertainty. And sitting with uncertainty is one of the hardest parts of faith.
+
+## What suffering can be
+
+Suffering doesn't have a reason. But it can have a response.
+
+When you suffer — and you will — you face a choice. The same choice Job faced, the same choice Jesus faced in Gethsemane. Do you walk away from the mission, or do you carry it through the pain?
+
+**Suffering can forge honesty.** The pretense that everything is fine collapses when the floor drops out. You discover what you actually believe, as opposed to what you've been saying you believe. David's rawest psalms — the ones where he accuses God of hiding, of forgetting, of sleeping ([Psalm 13][6], [Psalm 22][7], [Psalm 44][8]) — are the most honest prayers in Scripture. They're also the ones Jesus quoted from the cross.
+
+**Suffering can build compassion.** Paul wrote:
+
+> "Blessed be the God and Father of our Lord Jesus Christ, the Father of mercies and God of all comfort, who comforts us in all our affliction, so that we may be able to comfort those who are in any affliction, with the comfort with which we ourselves are comforted by God."
+— [2 Corinthians 1:3-4 ESV][9]
+
+The person who has suffered knows what suffering feels like. That knowledge — not theological expertise, not advice, not platitudes — is what actually helps someone who is hurting.
+
+**Suffering can clarify priorities.** You find out what matters when what doesn't matter gets stripped away. Health. Relationships. Purpose. The promotion, the house, the retirement portfolio — they recede. What remains is what was always real.
+
+None of this makes suffering good. Suffering is not a gift. It is not a blessing in disguise. It is not something to be grateful for. It's damage. But the response to damage is where character is built — and character is what the mission requires.
+
+## The hardest case
+
+Everything above meets its limit at one point: the suffering of the innocent. A child who has made no choices. An infant born into famine. A person with severe disabilities who never had the chance to carry the mission at all.
+
+There is no theological answer that makes this okay. Any framework that claims to fully explain the suffering of the innocent is lying to you.
+
+What can be said is this: the suffering of the innocent is not God's will, God's plan, or God's tool. It is the cost of a world that runs on its own laws. And the mission — the whole mission — is partly about building a world where that suffering is reduced. Every medical breakthrough, every act of care for the vulnerable, every system built to protect the powerless is humanity doing exactly what we were put here to do.
+
+You will encounter suffering you cannot explain. When you do, resist the urge to explain it. Sit with the people who are hurting. Do the practical work of reducing the damage. And carry the mission forward — not because suffering makes sense, but because the response to suffering is where the mission becomes real.
+
+## Questions to sit with
+
+* When you've suffered, what did you discover about what you actually believe — as opposed to what you thought you believed?
+* Have you ever told someone that "God has a plan" for their suffering? What did that accomplish?
+* What is the difference between believing suffering has a *reason* and choosing to make suffering produce a *response*?
+
+[1]: https://www.esv.org/Job+1/
+[2]: https://www.esv.org/Job+38/
+[3]: https://www.esv.org/Job+42/
+[4]: https://www.esv.org/John+11/
+[5]: https://www.esv.org/Matthew+27/
+[6]: https://www.esv.org/Psalm+13/
+[7]: https://www.esv.org/Psalm+22/
+[8]: https://www.esv.org/Psalm+44/
+[9]: https://www.esv.org/2+Corinthians+1/


### PR DESCRIPTION
## Summary

- Tackles theodicy (the Problem of Evil) head-on — no platitudes, no evasions
- Job as the Bible's own answer: you won't always understand, and your friends who think they do are probably wrong
- Dismantles four standard Christian answers (testing, sin consequence, God's plan, Satan)
- Jesus and the prophets suffered *because* they carried the mission, not despite it
- "What suffering is not" section: not punishment, not a test, not God's plan, not always explainable
- "What suffering can be" section: honesty, compassion, clarity — but never a gift
- The hardest case (innocent suffering) gets no tidy answer, only the honest response: reduce the damage and carry forward
- 9 ESV references (Job, Matthew, John, Psalms, 2 Corinthians)

## Consistency check

- Tenet 3 (hands-off God): suffering is mechanics, not divine action
- Prophet framing: Jesus suffered as the most faithful mission-carrier, not as divine sacrifice
- No substitutionary atonement language
- No "obedience" framing
- No "this book" self-references
- Callbacks to Hours 1, 9, 10, 11, 14, 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)