### PR TITLE
Draft Chapter 18: Forgiveness

### DIFF
--- a/manuscript/ch18-forgiveness.md
+++ b/manuscript/ch18-forgiveness.md
@@ -1,0 +1,112 @@
+# Hour 18: Forgiveness
+
+Q: How many times do I have to forgive someone?
+A: Every time. That's the answer you don't want.
+
+## Commentary
+
+Peter asked Jesus the same question:
+
+> "Lord, how often will my brother sin against me, and I forgive him? As many as seven times?" Jesus said to him, "I do not say to you seven times, but seventy-seven times."
+— [Matthew 18:21-22 ESV][1]
+
+Peter thought he was being generous. Jewish teaching at the time suggested forgiving someone three times. Peter doubled it and added one. Surely seven was enough.
+
+Jesus multiplied it out of range. Seventy-seven. Some translations say seventy times seven — 490. Either way, the number is not the point. The point is that forgiveness doesn't have a limit. The moment you set one, you've replaced forgiveness with accounting.
+
+## What forgiveness is
+
+Forgiveness is a release. Not a feeling — a decision. You let go of the debt someone owes you. Not because they've earned it. Not because what they did was acceptable. Not because you've processed it emotionally and arrived at peace. You let go because holding onto it is destroying you from the inside — and pulling you away from the mission.
+
+Hour 14 introduced this in the practice of prayer: name the wound, and let it go. Not because the person who hurt you deserves release, but because carrying it is a weight you were not designed to bear. Forgiveness is what happens when you choose the mission over the grudge.
+
+This is hard. It should be. Forgiveness that costs nothing isn't forgiveness — it's indifference. Real forgiveness means acknowledging that you were genuinely wronged, that the pain is real, that justice was not served — and choosing to release the debt anyway. That choice is one of the most difficult things a human being can do.
+
+Jesus demonstrated it on the cross:
+
+> "Father, forgive them, for they know not what they do."
+— [Luke 23:34 ESV][2]
+
+He said this while being executed. Not after. Not from a safe distance. Not once the pain had faded. While it was happening. That's the standard — not as a rule to follow mechanically, but as proof that forgiveness is possible even when everything in you says it shouldn't be.
+
+## What forgiveness is not
+
+**Forgiveness is not excusing.** "It's fine" is not forgiveness. "They didn't mean it" is not forgiveness. "It wasn't that bad" is not forgiveness. These are minimizations — pretending the wound doesn't exist so you don't have to deal with it. Genuine forgiveness requires you to name exactly what was done and acknowledge that it was wrong. You cannot forgive what you refuse to see clearly.
+
+**Forgiveness is not forgetting.** "Forgive and forget" is a cultural saying, not a biblical one. The Bible never asks you to pretend something didn't happen. Remembering protects you from putting yourself in the same position again. You can forgive the person who betrayed your trust and still choose not to give them access to betray it again. Memory is not the same as a grudge.
+
+**Forgiveness is not reconciliation.** This is the one most churches get wrong. Forgiveness is one-sided — it's something you do regardless of the other person's response. Reconciliation is two-sided — it requires repentance, changed behavior, and rebuilt trust. You can forgive someone who never apologizes. You should not reconcile with someone who hasn't changed.
+
+An abused spouse can forgive their abuser and still leave. A person who was betrayed can release the bitterness and still set boundaries. Forgiveness frees you from the emotional prison. It does not obligate you to walk back into the situation that created it.
+
+**Forgiveness is not weakness.** The instinct to hold a grudge feels like strength. It feels like justice. It feels like you're maintaining your dignity by refusing to let someone off the hook. But a grudge doesn't punish the person who hurt you — it punishes you. You carry the weight. You replay the offense. You let the person who wronged you live in your head rent-free, shaping your emotions and your decisions long after the event itself has passed. Releasing that is not weakness. It's the harder choice.
+
+## The parable Jesus told next
+
+Immediately after telling Peter to forgive without limit, Jesus told a story:
+
+> "Therefore the kingdom of heaven may be compared to a king who wished to settle accounts with his servants. When he began to settle, one was brought to him who owed him ten thousand talents."
+— [Matthew 18:23-24 ESV][1]
+
+Ten thousand talents was an absurd amount — millions in modern currency. The servant couldn't pay. The king forgave the entire debt. Then that same servant went out and found a fellow servant who owed him a hundred denarii — a few months' wages — and had him thrown in prison.
+
+When the king heard about it, he was furious:
+
+> "You wicked servant! I forgave you all that debt because you pleaded with me. And should not you have had mercy on your fellow servant, as I had mercy on you?"
+— [Matthew 18:32-33 ESV][1]
+
+The parable is about proportion. Every person alive has been carried by someone else's forgiveness — a parent who overlooked your failures, a friend who gave you a second chance, a stranger who chose kindness when you didn't deserve it. The debts you owe are larger than the debts owed to you. Refusing to forgive a small debt while benefiting from large ones is the hypocrisy the parable exposes.
+
+This is not about God keeping a cosmic ledger. It's about self-awareness. If you honestly examine your own life — the times you were selfish, cruel, negligent, cowardly — you'll find that you've been forgiven more than you realize. Extending that same grace to others is not an obligation imposed from above. It's the only honest response to how much grace you've already received.
+
+## Forgiving the unforgivable
+
+Some wrongs feel like they cannot be forgiven. The abuse of a child. A betrayal that destroyed a family. Violence that took someone you loved. Systemic injustice that crushed entire communities. These are not small debts.
+
+This chapter will not tell you that you must forgive these things on a timeline. Forgiveness of this magnitude is a process, not a moment. It may take years. It may require professional help. It may come in stages — releasing one layer of bitterness while another still grips you.
+
+What this chapter will say is that the alternative — carrying the wound as your identity, letting the offense define the rest of your life — is its own form of destruction. The person who hurt you may never face justice. They may never apologize. They may never even understand what they did. Your forgiveness is not for them. It's for you. It's the decision that what happened to you will not be the final word on who you become.
+
+Joseph — sold into slavery by his own brothers, imprisoned for years on false charges — eventually rose to power in Egypt. When his brothers appeared before him, terrified, he said:
+
+> "As for you, you meant evil against me, but God meant it for good, to bring it about that many people should be kept alive, as they are today."
+— [Genesis 50:20 ESV][3]
+
+Joseph didn't minimize what they did. He named it: "You meant evil." And he didn't claim the suffering was pleasant or deserved. But he chose to see what came after the suffering as more defining than the suffering itself. That's not a formula — it's a direction. Not every story resolves this neatly. But the direction matters.
+
+## Forgiveness and the mission
+
+The mission from Hour 1 — prove we can overcome our fears and vices — runs directly through forgiveness. Unforgiveness is a vice. It's the decision to let a past wrong control your present choices. It shrinks your capacity for love, corrodes your relationships, and turns you inward when the mission requires you to turn outward.
+
+Every community described in Hour 15 — every real one, not the comfortable social club — will produce wounds. People will let you down. Leaders will fail. Friends will betray. The question is not whether you'll be hurt. The question is whether you'll let the hurt end the mission.
+
+Paul wrote:
+
+> "Be kind to one another, tenderhearted, forgiving one another, as God in Christ forgave you."
+— [Ephesians 4:32 ESV][4]
+
+The early church was not a group of perfect people. It was a group of forgiven people who kept choosing to forgive each other. Peter denied Jesus three times and was restored. Paul persecuted the church and was welcomed into it. Mark abandoned Paul's missionary journey and was eventually reconciled ([2 Timothy 4:11][5]). Every one of those stories could have ended differently if someone had decided that the offense was unforgivable.
+
+The mission survives on forgiveness. Not because forgiveness is easy or automatic, but because the alternative — a community that holds grudges, keeps score, and cuts people off when they fail — cannot sustain itself. It collapses under the weight of accumulated resentment.
+
+## The daily practice
+
+Forgiveness is not a one-time event. It's a discipline — like prayer, like love, like every other practice in Part III.
+
+The Lord's Prayer puts it in the middle of the daily alignment: "Forgive us our debts, as we also have forgiven our debtors." Every day. Not once. Every day you examine what you're carrying, name it, and choose to let it go.
+
+Some days you'll succeed. Some days the old bitterness will return — the memory, the anger, the sense of injustice. That doesn't mean your forgiveness failed. It means you're human. The practice is in the returning. You let it go, it comes back, you let it go again. Seventy-seven times.
+
+The point is not perfection. The point is direction. Are you moving toward release or toward resentment? That direction — chosen daily, often against your own instincts — is what forgiveness looks like in practice.
+
+## Questions to sit with
+
+* Who are you refusing to forgive right now? What is that refusal costing you — not them, you?
+* Have you confused forgiveness with reconciliation? Is there someone you've forgiven but need to maintain distance from — and is there someone you've cut off entirely when forgiveness might free you?
+* The parable of the unforgiving servant asks you to compare the debts you hold against others with the debts others have forgiven in you. How does that comparison look when you're honest about it?
+
+[1]: https://www.esv.org/Matthew+18/
+[2]: https://www.esv.org/Luke+23/
+[3]: https://www.esv.org/Genesis+50/
+[4]: https://www.esv.org/Ephesians+4/
+[5]: https://www.esv.org/2+Timothy+4/


### PR DESCRIPTION
## Summary
- Final chapter of Part III (The Life)
- Forgiveness as release and discipline, not emotion or divine obligation
- What forgiveness is: choosing the mission over the grudge, letting go of the debt
- What forgiveness is NOT: excusing, forgetting, reconciliation, or weakness
  - Forgiveness/reconciliation distinction is key — you can forgive and still set boundaries
  - "An abused spouse can forgive their abuser and still leave"
- Peter's question (70x7), the unforgiving servant parable, Jesus on the cross
- Joseph and his brothers — named the evil, chose what came after
- Forgiveness as daily discipline (Lord's Prayer), not one-time event
- 112 lines, 5 ESV references
- No "this book" self-references, no divine transaction framing

## Test plan
- [ ] Voice check — direct, no hedging, consistent with Part III
- [ ] Theology check — no "God forgave you so you must" transactional framing, consistent with tenets
- [ ] Forgiveness ≠ reconciliation distinction is clear and pastoral
- [ ] Connects to Ch 14 (prayer/forgiveness), Ch 15 (community produces wounds), Ch 17 (suffering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)