### PR TITLE
Draft Ch 23: Death and What Comes After

### DIFF
--- a/manuscript/ch23-death-and-afterlife.md
+++ b/manuscript/ch23-death-and-afterlife.md
@@ -63,21 +63,35 @@ Christians hold at least three major positions on what happens to those who pers
 
 **Universal restoration (apokatastasis)** — Eventually, all people are reconciled to God. The "fire" of judgment is purifying, not punitive. God's love wins in the end because God does not give up. Early church fathers including Origen and Gregory of Nyssa held this view. Passages like "God desires all people to be saved" ([1 Timothy 2:4][7]) and "every knee shall bow" ([Philippians 2:10-11][8]) anchor it.
 
-Each view has biblical support. Each has serious theological defenders across two thousand years. The question is: which one is most consistent with the story?
+Each view has biblical support. Each has serious theological defenders across two thousand years. We believe universal restoration — and here is why.
 
-## What "humanity growing up" implies
+## Consider the people
 
-If the Bible tells the story of humanity maturing — growing from children needing rules into adults carrying the mission freely — then what does that imply about the afterlife?
+Before the theology, consider the lives.
 
-A parent who tortures a child forever for failing to grow up is not a parent. That is a tyrant. Eternal conscious torment, taken at face value, makes God worse than any human parent. It makes the mission coercive rather than invitational: "Love me or burn." That's not a relationship. It's a hostage situation.
+A child born on the autism spectrum who never experiences what society calls a "normal life." They may never articulate a creed, never pray a sinner's prayer, never sit in a pew. They experience the world differently. They love differently. Are they condemned for that?
 
-Annihilationism is coherent — it says the alternative to growth is simply to stop existing. No torture, just an end. But it also implies that God gives up. That some people are ultimately lost, and God accepts that loss.
+A baby who dies in the NICU — hours old, days old. Never spoke. Never chose anything. What theology accounts for that life? What kind of God creates a soul only to discard it because it never had the chance to "accept" anything?
 
-Universal restoration says: God is patient enough to wait. The "fire" of judgment is the same fire that refines gold — it burns away what is false, not the person. Growing up may take longer for some than others. The door remains open.
+A soldier sent to war at eighteen — told to die for their country, when countries are human fabrications designed to separate humanity and maintain self-serving power structures. They didn't choose the war. They were handed a rifle and told it was noble. If they die carrying out orders, are they judged for the killing? If they survive and carry the trauma forever, where is justice for them?
 
-This reading does not eliminate accountability. A child who refuses to mature still faces consequences — lost opportunities, broken relationships, the pain of stagnation. But the parent does not stop being a parent. The invitation does not expire.
+Mark Stroman walked into a Dallas convenience store after 9/11 and murdered Vasudev Patel — an immigrant from India who had nothing to do with the attacks. Dylann Roof sat in a Bible study at Mother Emanuel AME Church for an hour, prayed with the congregation, then murdered nine people because of the color of their skin. These men created incomprehensible pain. Their victims' families carry wounds that will never fully heal.
 
-You do not need to pick a position right now. But you should know that the version of hell preached most loudly — eternal torture for finite sins, decided in a single lifetime — is not the only option. It is not even the oldest option. And it is the option least consistent with a God whose defining characteristic, according to the Bible itself, is love ([1 John 4:8][9]).
+What does a loving and just God do with all of these people?
+
+## What we believe
+
+Eternal conscious torment says: the baby is in limbo, the soldier is judged, the murderer burns forever, and the autistic child who never prayed the right prayer is simply... lost. This makes God a bureaucrat — sorting paperwork, checking boxes, discarding anyone whose file is incomplete. A parent who tortures a child forever for failing to grow up is not a parent. That is a tyrant. "Love me or burn" is not a relationship. It is a hostage situation.
+
+Annihilationism says: those who don't make it simply cease to exist. No torture, just an end. But this implies God gives up. That some people — including babies, including those who never had a real chance — are ultimately lost, and God accepts that loss. A parent who shrugs and says "I tried" is not the God described in the parable of the lost sheep, who leaves the ninety-nine to find the one ([Luke 15:4][4]).
+
+Universal restoration says: God is patient enough to wait. The "fire" of judgment is the same fire that refines gold — it burns away what is false, not the person. The baby is not lost. The autistic child is not deficient. The soldier is not condemned for someone else's war. And yes — even Stroman, even Roof — face not annihilation but reckoning. They face the full weight of what they did, fully understood, fully felt. That is not mercy without justice. That is justice that leads somewhere.
+
+Growing up may take longer for some than others. The door remains open.
+
+This does not eliminate accountability. A child who refuses to mature still faces consequences — lost opportunities, broken relationships, the pain of stagnation. The murderer faces the enormity of lives destroyed. But the parent does not stop being a parent. The invitation does not expire. The God who "desires all people to be saved" ([1 Timothy 2:4][7]) does not desire it passively.
+
+The version of hell preached most loudly — eternal torture for finite sins, decided in a single lifetime — is not the oldest Christian position. Origen and Gregory of Nyssa held universal restoration in the early centuries. And it is the position most consistent with a God whose defining characteristic, according to the Bible itself, is love ([1 John 4:8][9]).
 
 ## Resurrection, not escape
 
@@ -95,7 +109,7 @@ Death is real. Loss is real. But the story does not end with loss. It ends with 
 ## Questions to sit with
 
 * If judgment is measured by how you loved the vulnerable — not by what you believed about God — how does that change your sense of urgency about your daily life?
-* Which view of the afterlife do you instinctively hold? Is that because you've studied it, or because it's what you were taught? Are you willing to consider the alternatives honestly?
+* Think of someone you consider irredeemable. Now ask: does God agree with you? What would it mean if restoration were possible even for them?
 * If "goat" is a posture you can change rather than a category you're born into, what posture are you choosing today?
 
 [1]: https://www.esv.org/Psalm+115/

--- a/manuscript/ch23-death-and-afterlife.md
+++ b/manuscript/ch23-death-and-afterlife.md
@@ -1,0 +1,110 @@
+# Hour 23: Death and What Comes After
+
+Q: What happens when we die?
+A: The honest answer is that Christians disagree. But the Bible's consistent picture is that death is not the end of accountability — and the measure is not what you believed but how you loved.
+
+## Commentary
+
+Every religion addresses death. Christianity is no exception. But the range of Christian belief about what happens after death is far wider than most people realize — and the loudest voices have not always been the most faithful to the text.
+
+What follows is not a definitive map of the afterlife. It is an honest reading of what the Bible says, what it doesn't say, and what the "humanity growing up" arc implies about death, judgment, and what comes after.
+
+## What the Bible actually says
+
+Less than you'd think.
+
+The Hebrew scriptures (Old Testament) have almost no developed afterlife theology. The dead go to *Sheol* — a shadowy, undifferentiated place. Not heaven, not hell. Just... gone. The Psalms occasionally reference Sheol as a place of silence where even praise ceases ([Psalm 115:17][1]). The emphasis in the Old Testament is overwhelmingly on *this* life — justice here, faithfulness now, the mission in the present.
+
+The New Testament introduces more language about resurrection and judgment, but even here, the details are sparse and often symbolic. Jesus speaks in parables. Revelation speaks in visions. Paul offers a theological framework but acknowledges its incompleteness: "For now we see in a mirror dimly" ([1 Corinthians 13:12][2]).
+
+What *is* consistent across the entire Bible:
+
+1. **Death is not the final word.** Something comes after.
+2. **There is accountability.** How you lived matters.
+3. **The criterion is love.** Not doctrinal correctness, not religious performance — love enacted toward the vulnerable.
+
+## The Sheep and the Goats
+
+The most vivid picture Jesus gives of judgment is in Matthew 25:
+
+> "When the Son of Man comes in his glory... he will separate people one from another as a shepherd separates the sheep from the goats."
+— [Matthew 25:31-32 ESV][3]
+
+The sheep — those who are welcomed — are identified not by their theology, not by their church attendance, not by their doctrinal correctness. They are identified by what they did:
+
+> "For I was hungry and you gave me food, I was thirsty and you gave me drink, I was a stranger and you welcomed me, I was naked and you clothed me, I was sick and you visited me, I was in prison and you came to me."
+— [Matthew 25:35-36 ESV][3]
+
+And the criterion that stings: "As you did it to one of the least of these my brothers, you did it to me" ([Matthew 25:40][3]).
+
+The goats — those who are turned away — are not atheists or pagans or members of the wrong religion. They are people who saw need and did nothing. They had the opportunity to love and chose comfort instead.
+
+This is the mission in miniature. The judgment is not about what you believed. It is about whether you loved the person in front of you who needed love.
+
+## "Goat" is a posture, not an identity
+
+Here is where we need to be careful — and where much of Christianity has gone wrong.
+
+The sheep-and-goats image is a parable. It describes a *posture* at a *moment of reckoning*. It does not describe a permanent category of human being. Nowhere does Jesus say: "Some of you were created as goats, and goats you will always be."
+
+In the arc of humanity growing up, a "goat" is someone who has refused to grow — someone who had the opportunity to participate in the mission and turned away. The question is whether that refusal is final.
+
+Read alongside the rest of Jesus' teaching — the prodigal son welcomed home after squandering everything ([Luke 15:11-32][4]), the workers hired at the eleventh hour receiving the full wage ([Matthew 20:1-16][3]), the thief on the cross promised paradise in his last moments ([Luke 23:43][5]) — the picture that emerges is not of an arbitrary sorting. It is of a God who relentlessly invites, who keeps the door open, who celebrates the late arrival as much as the early one.
+
+The goat posture is real. Some people genuinely turn away from love, from growth, from the mission. That choice has consequences. But the parable is a warning, not a census. It asks: *Which posture are you choosing right now?*
+
+## Three views of what "hell" means
+
+Christians hold at least three major positions on what happens to those who persistently refuse:
+
+**Eternal conscious torment** — The traditional view in Western Christianity. Those who reject God spend eternity in suffering. This is what most people picture when they hear "hell."
+
+**Annihilationism (conditional immortality)** — Those who refuse God simply cease to exist. Eternal life is a gift given to the faithful; the alternative is not torture but non-existence. Passages like "the wages of sin is death" ([Romans 6:23][6]) and "destroy both soul and body" ([Matthew 10:28][3]) support this reading.
+
+**Universal restoration (apokatastasis)** — Eventually, all people are reconciled to God. The "fire" of judgment is purifying, not punitive. God's love wins in the end because God does not give up. Early church fathers including Origen and Gregory of Nyssa held this view. Passages like "God desires all people to be saved" ([1 Timothy 2:4][7]) and "every knee shall bow" ([Philippians 2:10-11][8]) anchor it.
+
+Each view has biblical support. Each has serious theological defenders across two thousand years. The question is: which one is most consistent with the story?
+
+## What "humanity growing up" implies
+
+If the Bible tells the story of humanity maturing — growing from children needing rules into adults carrying the mission freely — then what does that imply about the afterlife?
+
+A parent who tortures a child forever for failing to grow up is not a parent. That is a tyrant. Eternal conscious torment, taken at face value, makes God worse than any human parent. It makes the mission coercive rather than invitational: "Love me or burn." That's not a relationship. It's a hostage situation.
+
+Annihilationism is coherent — it says the alternative to growth is simply to stop existing. No torture, just an end. But it also implies that God gives up. That some people are ultimately lost, and God accepts that loss.
+
+Universal restoration says: God is patient enough to wait. The "fire" of judgment is the same fire that refines gold — it burns away what is false, not the person. Growing up may take longer for some than others. The door remains open.
+
+This reading does not eliminate accountability. A child who refuses to mature still faces consequences — lost opportunities, broken relationships, the pain of stagnation. But the parent does not stop being a parent. The invitation does not expire.
+
+You do not need to pick a position right now. But you should know that the version of hell preached most loudly — eternal torture for finite sins, decided in a single lifetime — is not the only option. It is not even the oldest option. And it is the option least consistent with a God whose defining characteristic, according to the Bible itself, is love ([1 John 4:8][9]).
+
+## Resurrection, not escape
+
+One more clarification: the Christian hope is not "going to heaven when you die." That phrase appears nowhere in the Bible.
+
+The Christian hope is resurrection — the renewal of all things. The dead are raised. The world is restored. The mission reaches its completion. Revelation ends not with souls floating in clouds but with a city descending to earth:
+
+> "Behold, the dwelling place of God is with man. He will dwell with them, and they will be his people."
+— [Revelation 21:3 ESV][10]
+
+The endpoint is not escape from the physical world. It is the full redemption of it. God moves *in*, not away. The mission — love God, love your neighbor, extend that love to every corner of creation — reaches its fulfillment not in some ethereal afterlife but in a renewed creation where the mission is finally, fully accomplished.
+
+Death is real. Loss is real. But the story does not end with loss. It ends with restoration — and with the question of whether you participated in building what was restored.
+
+## Questions to sit with
+
+* If judgment is measured by how you loved the vulnerable — not by what you believed about God — how does that change your sense of urgency about your daily life?
+* Which view of the afterlife do you instinctively hold? Is that because you've studied it, or because it's what you were taught? Are you willing to consider the alternatives honestly?
+* If "goat" is a posture you can change rather than a category you're born into, what posture are you choosing today?
+
+[1]: https://www.esv.org/Psalm+115/
+[2]: https://www.esv.org/1+Corinthians+13/
+[3]: https://www.esv.org/Matthew+25/
+[4]: https://www.esv.org/Luke+15/
+[5]: https://www.esv.org/Luke+23/
+[6]: https://www.esv.org/Romans+6/
+[7]: https://www.esv.org/1+Timothy+2/
+[8]: https://www.esv.org/Philippians+2/
+[9]: https://www.esv.org/1+John+4/
+[10]: https://www.esv.org/Revelation+21/


### PR DESCRIPTION
## Summary

- Moves the Sheep and Goats passage from Ch 22 into its own full treatment here
- Explores judgment as accountability measured by love, not belief
- Frames "goat" as a posture (refusal to grow), not a permanent identity category
- Presents three views of hell (eternal torment, annihilationism, universal restoration) and evaluates each against the "humanity growing up" arc
- Clarifies that the Christian hope is resurrection/renewal, not escape to heaven

## Connections

- Pulls directly from the material removed from Ch 22 (PR #52)
- Builds on the "humanity growing up" throughline established across Parts I-III
- Sets up Ch 24 (milestones of maturity) by establishing what accountability looks like

🤖 Generated with [Claude Code](https://claude.com/claude-code)