### PR TITLE
Rewrite Chapter 4: Salvation

### DIFF
--- a/manuscript/ch04-salvation.md
+++ b/manuscript/ch04-salvation.md
@@ -1,44 +1,121 @@
-Q: How do I get into heaven?
-A: Jesus saves the faithful. So just be faithful to God.
+# Hour 4: Salvation
 
-## Commentary ##
+Q: If everyone sins, is anyone saved?
+A: Yes. Salvation is not a reward for the perfect — it is the process of choosing the mission over yourself, again and again, with help.
 
-We're all going to die one day. Morbid, perhaps, or just real. Death means our physical bodies are going to fail, our hearts will stop, our neurons will stop firing, and life as we know it will come to an end.
+## Commentary
 
-But God promises an afterlife. To be clear, God tells us that your soul will live on, heading toward a final judgment at which point you will be either granted eternal life (entry into heaven) or condemned to eternal death (no heaven for you). The only problem is that standard of conduct required for entry is high, unattainable high. So high, in fact, that you and I have already dropped the ball.
+The last chapter was blunt: every human being chooses self over the mission. Repeatedly. Reliably. The tendency is real, the data is in, and no honest person can exempt themselves.
 
-Luckily for us, Jesus came to earth and let himself be horribly tortured, humiliated and nailed to a wooden cross, so that you and I may know that we can be saved on that final day of judgment. When we come up short, Jesus will step in to save us. Not because we deserve it, for we will be saved by grace, not by merit.
+So where does that leave us? If the test is real and everyone fails — is the test unfair?
 
-Does this mean everyone will be saved? No. By faith you will be saved. Since your salvation hinges on a single word, "faith", the word bears some explanation, 
+No. The test was never pass/fail on the first attempt. Salvation is not a verdict handed down at the end of your life based on a perfect score. It is the ongoing work of reorientation — turning back toward the mission every time you drift. And you are not alone in doing it.
 
-In [the Parable of the Sower][1], Jesus explains the four stages of faith. Below are the stages and a few examples of what people at each stage may say, along with the expected verdict on the final day of judgment.
+## What salvation means
 
-* **Along the path**. "God is ridiculous. God doesn't exist." Death verdict.
-* **On rocky ground**. "God is great. Heaven sounds cool. But I really don't want to hear about these responsibilities." Death verdict.
-* **Among thorns**. "God is great. Heaven sounds cool. But these responsibilities are too heavy. My worldly comforts are too good to give up." Death verdict.
-* **On good soil**. "God is great. Heaven is real. Though I will stumble and fall, I know all I have is God's, and I gladly accept what I must do." _Life_ verdict.
+Strip away everything you've heard about salvation in church — the altar calls, the sinner's prayer, the "accept Jesus into your heart" formula — and ask the simplest possible question: saved from what?
 
-To figure out whether someone (including yourself) is spiritually stuck among thorns, try a few simple questions.
+The standard Christian answer is: saved from hell. Saved from God's wrath. Saved from the eternal consequences of your sin.
 
-* Are you saving for retirement? See [Acts 5:1-11][2].
-* Do you avoid talking honestly about your income and expenses? See [Acts 5:1-11][2].
-* Do you work in the financial services _industry_ (loans, insurance, securities, etc.)? See [Matthew 21:12-13][3].
-* Do you prioritize the _wants_ of yourself and your family (i.e., parents, siblings, spouse, children) first and foremost, putting the _needs_ of your Christian brothers and sisters at a distant second? See [Matthew 12:46-50][4].
+That framing turns God into a threat and Jesus into a shield. It makes the entire gospel a hostage negotiation: love me or burn. That is not the God described in Hour 1. A parent who creates children and then threatens them with eternal torture for failing to perform is not a loving parent. That is a tyrant.
 
-Basically, if there's any topic or subject you're not willing to examine as it may reveal a conflict with doing the will of God, you're probably stuck among thorns. And if you're offended by this statement, that's probably further objective proof of where you are in your faith.
+So what are you actually saved from?
 
-I'm sorry if this sounds harsh. It's harsh to me as well, even as I write this, but it's the truth. God sees through lip service ([James 2:14-17][8]), and there's no place for hypocrites in heaven ([Matthew 7:21-23][9]).
+You are saved from the pattern. The pattern of choosing self. The cycle of rationalization, indifference, and slow spiritual decay that Hour 3 described. Left alone, the tendency toward self wins. It always wins. You rationalize one compromise, then another, until you can no longer see the gap between who you are and who you were meant to be.
 
-Still, there is hope for us! We don't all have to become well known servant leaders like [Mother Teresa][5] or [Mahatma Ghandi][6], but simply _working_ earnestly to change your answers to questions like those above is a great place to start. And for most of us, having a community of believers who share similar struggles but also similar desires to rise above those struggles would go a long way.
+Salvation is rescue from that trajectory — not by an external force overriding your choices, but by a model, a community, and a daily practice that keeps pulling you back toward the mission.
 
-Let's talk more about community in another chapter, but as a quick suggestion you could start with the [_Christianity in 24 Hours_ repo on GitHub][7].
+> Therefore, if anyone is in Christ, he is a new creation. The old has passed away; behold, the new has come.
+— [2 Corinthians 5:17 ESV][1]
 
-[1]: https://www.esv.org/Matthew+13/
-[2]: https://www.esv.org/Acts+5/
-[3]: https://www.esv.org/Matthew+21/
-[4]: https://www.esv.org/Matthew+12/
-[5]: https://www.biography.com/people/mother-teresa-9504160
-[6]: https://www.biography.com/people/mahatma-gandhi-9305898
-[7]: https://github.com/martyychang/christianity-in-24
-[8]: https://www.esv.org/James+2/
-[9]: https://www.esv.org/Matthew+7/
+Paul is not describing a legal status change. He is describing a reorientation so fundamental that it constitutes a new life. The "old" that passes away is the pattern — the default of self-over-others. The "new" that comes is the direction — mission over self, chosen daily.
+
+## Jesus and the gap
+
+Hour 3 established that every person falls short. The standard is love God, love your neighbor — and nobody sustains it. That gap between what we are and what the mission requires is real.
+
+Jesus bridges that gap. But not the way most churches explain it.
+
+The traditional framing says Jesus took the punishment for your sins — that God's justice demanded blood, and Jesus paid the price so you wouldn't have to. This is substitutionary atonement, and it has dominated Western Christianity for centuries. But it makes God a creditor and the cross a transaction. A God who requires the torture and death of his own prophet to satisfy his own rules is not a God of love. That is a God of accounting.
+
+Here is what Jesus actually did: he lived the mission without faltering. That's it. That's everything.
+
+One human being — blessed by God, yes, but human — faced every temptation, every pressure, every opportunity to choose self over others, and chose the mission every time. All the way to the cross. He didn't want to die. He asked God to take the cup from him ([Luke 22:42][2]). The test was real. He chose the mission anyway.
+
+That is the bridge. Not a cosmic debt payment. A proof of concept. The gap between human failure and God's standard is crossable — because one person crossed it. Jesus proved it can be done.
+
+And in proving it, he gave us something no amount of Law or prophets ever could: a living example of what faithfulness looks like when the cost is everything. The Law told you what to do. Jesus showed you what it looks like.
+
+> For we do not have a high priest who is unable to sympathize with our weaknesses, but one who in every respect has been tempted as we are, yet without sin.
+— [Hebrews 4:15 ESV][3]
+
+## Grace: the door stays open
+
+You will fail. That is not a prediction — it is a certainty. You will choose self over mission tomorrow, and the day after, and the day after that. Not every time. But often enough that perfection is not the standard.
+
+Grace is the fact that your failures do not disqualify you.
+
+> But God shows his love for us in that while we were still sinners, Christ died for us.
+— [Romans 5:8 ESV][4]
+
+Read that carefully. Not "after we cleaned ourselves up." Not "once we proved we were worthy." *While we were still sinners.* The door to the mission was opened before anyone earned it — because earning it was never the point.
+
+Grace is not permission to keep failing. It is the assurance that the mission doesn't reject you for having failed. You fell off the path. You can get back on. That option does not expire.
+
+Peter denied Jesus three times the night before the crucifixion — after swearing he never would ([Luke 22:54-62][5]). After the resurrection, Jesus found Peter and asked him one question, three times: "Do you love me?" Three chances to reverse three denials. No lecture. No punishment. No probationary period. Just: do you love me? Then feed my sheep ([John 21:15-17][6]).
+
+That is grace. Not the absence of accountability — Peter had to face what he did. But the refusal to let failure be the final word.
+
+## The Parable of the Sower
+
+Jesus told a story about a farmer scattering seed on different types of soil ([Matthew 13:3-9][7]). The seed is the same — the mission, the invitation. What changes is the soil — the condition of the person receiving it.
+
+Some seed falls on the path — hard ground. It never takes root. These are people who hear the mission and dismiss it outright. Not out of honest inquiry — out of refusal to engage.
+
+Some falls on rocky ground. It sprouts fast but has no depth. These are people who get excited about faith but abandon it the moment it costs something. The first real sacrifice, the first hard question, and they're gone.
+
+Some falls among thorns. It grows but gets choked. These are people who genuinely want to carry the mission but allow other priorities — comfort, wealth, reputation, fear — to slowly crowd it out until nothing remains but the label.
+
+Some falls on good soil. It grows and produces — thirty, sixty, a hundredfold.
+
+Here is what this parable is *not*: a permanent sorting system. It is not four fixed categories of human being. It is a description of postures — and postures can change. The same person can be rocky ground at twenty and good soil at forty. The same person can be good soil on Monday and thorns by Friday. The question is not "which category are you?" The question is: what is choking the seed right now, and are you willing to pull it out?
+
+The parable is a diagnostic tool, not a verdict.
+
+## Saved by faith
+
+So how does this work? If salvation is ongoing reorientation, what keeps you oriented?
+
+Faith.
+
+Not belief — not intellectual agreement that God exists. Faith is the active, daily choice to keep walking toward the mission even when the evidence seems against it, even when it costs you, even when you've failed seventeen times already and the eighteenth attempt feels pointless.
+
+> For by grace you have been saved through faith. And this is not your own doing; it is the gift of God.
+— [Ephesians 2:8 ESV][8]
+
+Grace opens the door. Faith is walking through it — not once, but every day. The next chapter unpacks what that looks like in practice.
+
+## Not alone
+
+One more thing. The closing of Hour 3 said you are not alone in fighting the tendency toward self. That is not a platitude.
+
+Salvation is not a solo project. You are not meant to white-knuckle your way toward faithfulness in isolation. The mission was always designed to be carried together — Jesus called twelve people, not one. The early church shared everything. Paul's letters are addressed to communities, not individuals. Every time someone in the New Testament tries to carry the mission alone, they burn out, break down, or betray.
+
+You will need people who see you honestly and love you anyway. People who call you back when you drift. People who carry the weight with you on the days you can't carry it yourself. That is what the church was supposed to be — not a building, not an institution, but a group of people committed to carrying each other toward the mission.
+
+You will be saved by faith. But faith is not lived in isolation. The rest of Part I is about what that looks like.
+
+## Questions to sit with
+
+* If salvation is not a one-time event but an ongoing reorientation, how does that change your sense of urgency about how you live today — not someday, today?
+* What would you need to hear from God after your worst failure? Is it punishment — or Peter's question: "Do you love me? Then keep going"?
+* What is choking the seed in your life right now — comfort, fear, busyness, cynicism? Name it honestly.
+
+[1]: https://www.esv.org/2+Corinthians+5/
+[2]: https://www.esv.org/Luke+22/
+[3]: https://www.esv.org/Hebrews+4/
+[4]: https://www.esv.org/Romans+5/
+[5]: https://www.esv.org/Luke+22/
+[6]: https://www.esv.org/John+21/
+[7]: https://www.esv.org/Matthew+13/
+[8]: https://www.esv.org/Ephesians+2/


### PR DESCRIPTION
## Summary

- Full rewrite of Ch 4 (Salvation) — original content was from 2017 and used substitutionary atonement, eternal torment framing, and harsh sorting language incompatible with the book's established theology
- Salvation reframed as ongoing reorientation (not one-time verdict), Jesus as proof of concept (not cosmic debt payment), grace as the door staying open (Peter's reinstatement)
- Parable of the Sower retained but reimagined as diagnostic tool, not permanent categories
- Bridges Ch 3 (sin → everyone fails) to Ch 5 (faith → what keeps you oriented)
- ~130 lines, 8 ESV references

## Voice compliance

- No substitutionary atonement ✓
- No "obedience" language ✓
- No "this book" self-references ✓
- No double negatives ✓
- No plan/blueprint metaphors for God ✓
- Jesus as prophet with special blessings, not incarnation ✓
- Affirmative framing ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)