### PR TITLE
Add lending and capitalism section to Hour 16 (Giving)

### DIFF
--- a/manuscript/ch16-giving.md
+++ b/manuscript/ch16-giving.md
@@ -72,6 +72,32 @@ And when people tried to game the system — holding back while pretending to gi
 
 Ananias and Sapphira didn't die because they kept some money. They died because they lied about it. They wanted the reputation of total generosity without the actual sacrifice. God doesn't need your money. God needs your honesty.
 
+## Why we lend instead of give
+
+The early church didn't have a mortgage program. They didn't offer microloans to their members. They didn't charge interest on anything. They shared. If someone needed a house, the community housed them. If someone needed food, the community fed them. No paperwork. No repayment schedule. No profit margin.
+
+So what happened?
+
+The Bible is consistently hostile to lending for profit. The Old Testament prohibits charging interest to those in need ([Exodus 22:25][9], [Leviticus 25:35-37][10]). Ezekiel lists usury alongside bloodshed and adultery as sins that defile a nation ([Ezekiel 18:13][11]). The Year of Jubilee — every fifty years — cancelled all debts and returned all land to its original owners ([Leviticus 25:8-13][10]). A hard reset, by design, to prevent the permanent accumulation of wealth by a few at the expense of everyone else.
+
+Jesus flipped the money-changers' tables. That wasn't a footnote — it was one of the only times he used physical force. The people profiting from others' need, inside a sacred space, enraged him more than almost anything else recorded in the gospels.
+
+The principle underneath all of it: **don't profit from your neighbor's need.**
+
+Lending exists because we stopped sharing. A mortgage puts a family in a home — but only if they pay back the principal plus profit over thirty years. A student loan funds an education — but only if the borrower spends a decade paying interest to a bank. A microloan starts a business in a village — but someone still takes a cut. Every one of these transactions does something good while extracting something from the person who can least afford to give it.
+
+Why not just give?
+
+That question sounds naive. It isn't. It's the question the early church answered every day. They gave because they trusted each other, because the community was real, because "not a needy person among them" was the actual standard — not a metaphor, not an aspiration, but the way they lived.
+
+Lending is what happens when that trust breaks down. Interest is the price of a missing community. The entire financial system — mortgages, credit cards, student loans, payday lenders — is an elaborate substitute for people who simply take care of each other. Some of those substitutes are better than others. A fair mortgage is better than homelessness. A student loan is better than no education. But none of them are the destination. They are scaffolding for a house that was never built.
+
+Capitalism organized human productivity more efficiently than what came before it. That's true. But the Law organized Israelite society more efficiently than what came before it, and the Law was still parenting on a civilizational scale — rules for a species that hadn't grown up enough to do the right thing without being told. Capitalism is the same kind of scaffolding. Useful for a stage. Not the endpoint.
+
+The endpoint is Acts 2. The endpoint is a community where no one needs to borrow because no one is left without. The victory conditions from Hour 24 — food security, housing security, education without gatekeepers — describe a world where most lending becomes unnecessary. Not because lending was outlawed, but because the need for it disappeared.
+
+If you work in financial services, the question is not whether your job is sinful. The question is whether you're using your position to move toward giving or to perpetuate the gap. Are you building products that trap people in debt, or products that help them escape it? Are you profiting from desperation, or reducing it? The industry you're in matters less than the direction you're pointed.
+
 ## Giving and the mission
 
 Remember the mission from Hour 1? Humanity proving we can overcome our fears and vices to sustainably manage the earth. Giving is how that mission gets funded — not in the institutional sense, but in the human sense.
@@ -101,3 +127,6 @@ The tithe was never the point. The point is whether you're willing to hold your 
 [6]: https://www.esv.org/Acts+4/
 [7]: https://www.esv.org/Acts+5/
 [8]: https://www.esv.org/Mark+12/
+[9]: https://www.esv.org/Exodus+22/
+[10]: https://www.esv.org/Leviticus+25/
+[11]: https://www.esv.org/Ezekiel+18/


### PR DESCRIPTION
## Summary

- Adds "Why we lend instead of give" section to Chapter 16, placed after "The early church got this right" — the natural follow-up to Acts 2:44-45
- Bible's anti-usury stance: Exodus 22:25, Leviticus 25, Ezekiel 18, Jubilee, table-flipping
- Core insight: lending exists because we stopped sharing. Interest is the price of a missing community.
- Capitalism framed as developmental scaffolding — like the Law, useful for a stage, not the endpoint
- Endpoint is Acts 2: a community where no one needs to borrow because no one is left without
- Challenge to readers in finance: not "is your job sinful?" but "which direction are you pointed?"

Closes #8

## Test plan

- [ ] Read section in context of full chapter — voice and flow consistency
- [ ] Verify scripture references link correctly
- [ ] Confirm the section bridges naturally from "early church" to "giving and the mission"

🤖 Generated with [Claude Code](https://claude.com/claude-code)