### PR TITLE
Editorial consistency pass: remove self-references, fix population

### DIFF
--- a/manuscript/ch01-god.md
+++ b/manuscript/ch01-god.md
@@ -29,7 +29,7 @@ God created humanity with a mission. Think of it this way: God has a vision for 
 
 ## Who is Satan, really?
 
-Here's where this book parts ways with most of what you've heard.
+Here's where things part ways with most of what you've heard.
 
 Satan is not God's arch-nemesis. Satan is not an equal and opposite force of evil locked in a cosmic war with good. Read the Book of Job carefully — it's one of the most misunderstood books in the Bible.
 
@@ -64,7 +64,7 @@ Jesus answered this directly. No ambiguity, no fine print.
 
 Love God. Love other people. Everything else in the Bible hangs on those two commands. And notice: the mission — stewarding the earth, taking care of each other, proving we can do this — is really just a concrete expression of those two commandments lived out at scale.
 
-Simple to understand. Extraordinarily difficult to live. And that tension between understanding and living is what the rest of this book is about.
+Simple to understand. Extraordinarily difficult to live. And that tension between understanding and living is what the next twenty-two hours are about.
 
 ## Questions to sit with
 
@@ -72,7 +72,7 @@ Simple to understand. Extraordinarily difficult to live. And that tension betwee
 * Do you believe humanity's problems are solvable, or have you already decided we're doomed? What does your answer say about your faith?
 * When you hear "love your neighbor as yourself," who is the neighbor you find hardest to love?
 
-That last question matters more than you think. Because the mission isn't abstract — it's built from seven billion individual choices to love or not love the person in front of you.
+That last question matters more than you think. Because the mission isn't abstract — it's built from eight billion individual choices to love or not love the person in front of you.
 
 [1]: https://www.esv.org/Genesis+6/
 [2]: https://www.esv.org/Genesis+1/

--- a/manuscript/ch02-the-bible.md
+++ b/manuscript/ch02-the-bible.md
@@ -5,7 +5,7 @@ A: Yes. But that doesn't mean what most people think it means.
 
 ## Commentary
 
-You've made it to Hour 2, which means you're still here. Good. Because this chapter is about the book that the rest of this book won't stop quoting, and you need to understand what you're holding so that everything after this lands the way it should.
+You've made it to Hour 2, which means you're still here. Good. Because this chapter is about the book that the next twenty-two hours won't stop quoting, and you need to understand what you're holding so that everything after this lands the way it should.
 
 The Bible is not a rulebook. It's not an instruction manual. It's not a single document written by one author with one message. And it is absolutely not a weapon to be aimed at people you disagree with.
 
@@ -53,9 +53,9 @@ A sword cuts. If the Bible has never cut you — never made you question your ow
 
 ## Why this matters for the rest of the book
 
-The preface of this book told you to read the Bible for yourself after you finish here. That wasn't a suggestion. It was the whole point. This book is a map. The Bible is the territory. And maps are useful, but they're no substitute for walking the ground yourself.
+The preface told you to read the Bible for yourself after you finish here. That wasn't a suggestion. It was the whole point. These twenty-four hours are a map. The Bible is the territory. And maps are useful, but they're no substitute for walking the ground yourself.
 
-If you disagree with something in this book, good. Go back to the mission and think critically about whether the disagreement holds up. If a pastor tells you something that sounds off, measure it against the mission. If a friend quotes a verse to win an argument, ask whether that interpretation serves the mission or just serves their point.
+If you disagree with something here, good. Go back to the mission and think critically about whether the disagreement holds up. If a pastor tells you something that sounds off, measure it against the mission. If a friend quotes a verse to win an argument, ask whether that interpretation serves the mission or just serves their point.
 
 The mission is grounded in the Bible. It is the product of reading the whole thing, thinking hard about why it exists, and arriving at an understanding of what God set in motion and what humanity is supposed to do about it. You can question the mission — that is fine, and it is encouraged. But question it honestly, with the full weight of Scripture behind you, not with a single verse pulled from a Google search.
 

--- a/manuscript/ch06-holy-spirit.md
+++ b/manuscript/ch06-holy-spirit.md
@@ -55,7 +55,7 @@ The apostles spread the gospel across the Mediterranean world. Communities of be
 
 ## What we have now
 
-This book takes a clear position: the Holy Spirit's active, supernatural role was specific to the early church's founding mission. It equipped people who had nothing else. We are not those people.
+The position is clear: the Holy Spirit's active, supernatural role was specific to the early church's founding mission. It equipped people who had nothing else. We are not those people.
 
 We have the complete Bible — sixty-six books recording everything God wanted humanity to know. We have two thousand years of scholarship, translation, and commentary. We have the detailed example of Jesus's life, teachings, death, and resurrection, preserved in four independent accounts. We have communities of believers on every continent. We have literacy, printing, the internet — the ability to access Scripture in hundreds of languages from anywhere on earth.
 
@@ -101,7 +101,7 @@ The Spirit's legacy is not an ongoing whisper in your ear. It is the standard it
 
 Hour 1 established the mission: humanity proving we can overcome our fears and vices to sustainably manage the earth. Satan's bet is that we'll fail. God is watching.
 
-If God is actively directing individuals through the Spirit, the test is rigged. You cannot simultaneously claim that humans have free will and that God is whispering instructions in their ears. Either the choices are ours or they aren't. This book says they are — fully, completely, and without a safety net.
+If God is actively directing individuals through the Spirit, the test is rigged. You cannot simultaneously claim that humans have free will and that God is whispering instructions in their ears. Either the choices are ours or they aren't. They are — fully, completely, and without a safety net.
 
 That is harder than being led. It is also more honest. And it is the only framework in which faith means anything. If you're being guided, you don't need faith — you have GPS. Faith is what you need when you're navigating without a signal, using the map you were given, trusting that the destination is real even though you can't see it yet.
 

--- a/manuscript/ch07-creation-to-abraham.md
+++ b/manuscript/ch07-creation-to-abraham.md
@@ -46,7 +46,7 @@ The Fall opened the door. Cain walked through it.
 
 The first murder. One generation after creation. And Cain's response — "Am I my brother's keeper?" — is the most honest articulation of sin in the entire Bible. It's not a denial. It's a question: why should I be responsible for someone else?
 
-The answer, from this book's framework, is: because that is the entire mission. You are your brother's keeper. That's what "love your neighbor as yourself" means at its most basic. Every person you encounter is your responsibility, not in the sense that you control their outcomes, but in the sense that how you treat them is evidence in the trial.
+The answer is: because that is the entire mission. You are your brother's keeper. That's what "love your neighbor as yourself" means at its most basic. Every person you encounter is your responsibility, not in the sense that you control their outcomes, but in the sense that how you treat them is evidence in the trial.
 
 Cain chose self. And the consequence was exile — separation from the community, from the ground that would have sustained him, from God's direct presence. Sin doesn't just harm the victim. It isolates the one who commits it.
 
@@ -126,7 +126,7 @@ Abraham obeys. He binds Isaac, lays him on the altar, raises the knife. And God 
 > "Do not lay your hand on the boy or do anything to him, for now I know that you fear God, seeing you have not withheld your son, your only son, from me."
 — [Genesis 22:12 ESV][13]
 
-This is the hardest story in the Old Testament. It has troubled readers for millennia, and it should. But within the framework of this book, the point is this: God asked Abraham whether his faith was real — not as theology, not as cultural identity, not as a comfortable habit, but as something he would act on when the cost was everything he loved.
+This is the hardest story in the Old Testament. It has troubled readers for millennia, and it should. But the point is this: God asked Abraham whether his faith was real — not as theology, not as cultural identity, not as a comfortable habit, but as something he would act on when the cost was everything he loved.
 
 Abraham said yes. And God accepted the answer without requiring the sacrifice.
 

--- a/manuscript/ch08-moses-and-the-law.md
+++ b/manuscript/ch08-moses-and-the-law.md
@@ -45,7 +45,7 @@ Pharaoh relents. Israel leaves Egypt. And then Pharaoh changes his mind and send
 
 God parts the sea. Israel walks through on dry ground. The Egyptian army follows and is destroyed. It is the definitive act of rescue in the Old Testament.
 
-Here is the question this demands, given the framework of this book: if God could do *that*, why doesn't He intervene like that today?
+Here is the question this demands: if God could do *that*, why doesn't He intervene like that today?
 
 The answer is core tenet #2. God's direct interventions had a defined arc — a progression building toward Jesus. The Exodus was part of that arc. God was building a people, establishing a covenant nation, and setting the stage for everything that would follow. These interventions were not random acts of power. They were steps in a plan that had a beginning, a middle, and an end. The end came with Christ. After that, humanity has what it needs. The test is ours to pass or fail without the sea parting for us.
 

--- a/manuscript/ch10-jesus-the-life.md
+++ b/manuscript/ch10-jesus-the-life.md
@@ -20,7 +20,7 @@ He was a carpenter's son. He worked with his hands. He didn't emerge from a pala
 > The Spirit of the Lord is upon me, because he has anointed me to proclaim good news to the poor. He has sent me to proclaim liberty to the captives and recovering of sight to the blind, to set at liberty those who are oppressed.
 — [Luke 4:18 ESV][1]
 
-Those are Jesus's own words, reading Isaiah in his hometown synagogue — claiming the prophetic mantle. Anointed and sent, like Moses, like Elijah. The centuries of prophecy pointed to this man. But the distinction that matters for the whole arc of this book: unlike every prophet before him, Jesus would carry the mission all the way without faltering. Moses struck the rock. David fell with Bathsheba. Solomon turned to other gods. Jesus held.
+Those are Jesus's own words, reading Isaiah in his hometown synagogue — claiming the prophetic mantle. Anointed and sent, like Moses, like Elijah. The centuries of prophecy pointed to this man. But the distinction that matters for everything that follows: unlike every prophet before him, Jesus would carry the mission all the way without faltering. Moses struck the rock. David fell with Bathsheba. Solomon turned to other gods. Jesus held.
 
 ## What he taught
 
@@ -104,7 +104,7 @@ John's gospel captured this with a single line:
 
 Mainstream theology reads this as divine incarnation — God becoming human. But there is another way to hear it. The Word — God's message, the covenant, the mission that had been carved on stone, spoken through prophets, argued over by scholars — became flesh. It was lived. For the first time, someone didn't just teach the word or preach it or legislate it. Someone embodied it. The word on the tablet became a life.
 
-Every chapter of this book converges here. The mission from Hour 1 — humanity proving it can get this right. The sin from Hour 3 — choosing self over others. The faith from Hour 5 — a direction, not a moment. The Law from Hour 8 — childhood rules that Jesus translated into adult character. The prophets from Hour 9 — truth-tellers who pointed beyond themselves to someone who hadn't arrived yet.
+Every hour converges here. The mission from Hour 1 — humanity proving it can get this right. The sin from Hour 3 — choosing self over others. The faith from Hour 5 — a direction, not a moment. The Law from Hour 8 — childhood rules that Jesus translated into adult character. The prophets from Hour 9 — truth-tellers who pointed beyond themselves to someone who hadn't arrived yet.
 
 He arrived. A prophet with gifts no one else had — and the conviction to use them without flinching. Three years of showing what it looks like to choose the mission every single day — to love the unlovable, to confront the powerful, to welcome the outcast, to forgive the unforgivable — knowing that it would cost him everything. Where every prophet before him eventually faltered, Jesus held.
 

--- a/manuscript/ch11-jesus-death-resurrection.md
+++ b/manuscript/ch11-jesus-death-resurrection.md
@@ -11,9 +11,9 @@ This chapter is about what happened next. But before we get there, a framing tha
 
 Traditional Christianity teaches that Jesus died as a sacrifice — that God required a payment for humanity's sin, and Jesus was the payment. This is called substitutionary atonement, and it is the dominant framework in most churches. It says: you owed a debt you couldn't pay, Jesus paid it, and now you're free.
 
-This book takes a different path.
+There is a different path.
 
-Not because the sacrificial language isn't in the Bible — it is. But because within the framework we've built across ten chapters, the cross means something more specific than a cosmic transaction. Jesus was a prophet with gifts no one else had, who carried the mission without faltering where every prophet before him had broken. His death wasn't a payment. It was the final proof that faithful mission-carrying is possible — even when the cost is everything.
+Not because the sacrificial language isn't in the Bible — it is. But because within the framework built across the last ten hours, the cross means something more specific than a cosmic transaction. Jesus was a prophet with gifts no one else had, who carried the mission without faltering where every prophet before him had broken. His death wasn't a payment. It was the final proof that faithful mission-carrying is possible — even when the cost is everything.
 
 ## The last days
 
@@ -75,7 +75,7 @@ Crucifixion was designed to be the worst death the Roman Empire could devise. Na
 
 Jesus was beaten, mocked, stripped, and nailed to a cross between two criminals. A sign was placed above his head: "Jesus of Nazareth, the King of the Jews" — Rome's idea of a joke.
 
-From the cross, he said seven things. Two of them matter most for this book.
+From the cross, he said seven things. Two of them matter most for the mission.
 
 The first:
 
@@ -114,7 +114,7 @@ Three days later, the tomb was empty.
 > "He is not here, for he has risen, as he said. Come, see the place where he lay."
 — [Matthew 28:6 ESV][9]
 
-The resurrection is the most debated event in human history. Believers and skeptics have argued about it for two thousand years, and this book will not resolve that debate. What the resurrection means within the framework of this book is this:
+The resurrection is the most debated event in human history. Believers and skeptics have argued about it for two thousand years, and twenty-four hours will not resolve that debate. What the resurrection means within the framework of the mission is this:
 
 God confirmed the answer.
 

--- a/manuscript/ch12-the-early-church.md
+++ b/manuscript/ch12-the-early-church.md
@@ -50,7 +50,7 @@ On the road to Damascus, headed to arrest more Christians, something happened:
 
 Saul became Paul. The persecutor became the apostle. The man who tried to destroy the church became the person most responsible for building it.
 
-Within the framework of this book, Paul's conversion is significant for two reasons. First, it demonstrates that no one is beyond the reach of the mission. If the person who dragged believers to prison can become the greatest missionary in history, the question of "who qualifies?" is permanently answered: everyone. Second, Paul brought something the original disciples didn't have — education, Roman citizenship, and an understanding of both Jewish Law and Greek philosophy that allowed him to translate the message across cultures.
+Paul's conversion is significant for two reasons. First, it demonstrates that no one is beyond the reach of the mission. If the person who dragged believers to prison can become the greatest missionary in history, the question of "who qualifies?" is permanently answered: everyone. Second, Paul brought something the original disciples didn't have — education, Roman citizenship, and an understanding of both Jewish Law and Greek philosophy that allowed him to translate the message across cultures.
 
 ## The missionary journeys
 

--- a/manuscript/ch13-love-god-love-neighbor.md
+++ b/manuscript/ch13-love-god-love-neighbor.md
@@ -7,7 +7,7 @@ A: Love God, love your neighbor. Everything else is commentary.
 
 Part II told the story. Part III asks what you do with it.
 
-The transition matters. Knowing the story — creation, fall, Law, prophets, Jesus, the early church — is not the same as living it. You can read every chapter of this book, understand the framework, agree with the tenets, and still walk away unchanged. Knowledge without action is the older brother in the Prodigal Son parable: technically correct, spiritually empty.
+The transition matters. Knowing the story — creation, fall, Law, prophets, Jesus, the early church — is not the same as living it. You can read every chapter, understand the framework, agree with the tenets, and still walk away unchanged. Knowledge without action is the older brother in the Prodigal Son parable: technically correct, spiritually empty.
 
 Part III is about the doing. And it starts with the simplest, hardest thing Jesus ever said.
 
@@ -28,7 +28,7 @@ The maturation metaphor from Part II lands here. The Law gave children 613 rules
 
 Loving God is not an emotion. It is not a warm feeling during worship. It is not the rush you get at a concert-style church service with fog machines and a light show.
 
-Loving God, in the framework of this book, means orienting your life around the mission. The mission from Hour 1: prove we can overcome our fears and vices to sustainably manage the earth and love each other. Loving God means taking that mission seriously — not as an abstract idea you assent to, but as the organizing principle of your actual, daily, Tuesday-afternoon life.
+Loving God means orienting your life around the mission. The mission from Hour 1: prove we can overcome our fears and vices to sustainably manage the earth and love each other. Loving God means taking that mission seriously — not as an abstract idea you assent to, but as the organizing principle of your actual, daily, Tuesday-afternoon life.
 
 Jesus made this explicit:
 
@@ -97,7 +97,7 @@ Peter denied Jesus three times and still built the church. Paul persecuted Chris
 
 The remaining chapters of Part III are applications of these two commandments. Prayer (Hour 14) is how you orient toward God. Community (Hour 15) is how you practice love with people who share the mission. Giving (Hour 16) is love expressed through resources. Suffering (Hour 17) is what happens when love costs you something. Forgiveness (Hour 18) is love surviving betrayal.
 
-Everything comes back to this: love God, love your neighbor. If you remember nothing else from this book, remember that. Not as a bumper sticker. Not as a greeting card sentiment. As a daily, uncomfortable, relentless practice that will cost you more than you expect and give back more than you can measure.
+Everything comes back to this: love God, love your neighbor. If you remember nothing else from these twenty-four hours, remember that. Not as a bumper sticker. Not as a greeting card sentiment. As a daily, uncomfortable, relentless practice that will cost you more than you expect and give back more than you can measure.
 
 The story has been told. This is where the living starts.
 

--- a/manuscript/ch21-christianity-and-the-world.md
+++ b/manuscript/ch21-christianity-and-the-world.md
@@ -90,7 +90,7 @@ The answer depends on what you mean by Christianity. If you mean the institution
 
 If you mean the mission — love God, love your neighbor, overcome your fears and vices — then yes. The mission is not invalidated by the institution's failures. It is, in fact, vindicated by them. Every institutional corruption proves exactly what the mission claims: that humans left to their own instincts will choose power over love, self-preservation over sacrifice, comfort over justice. The mission exists because that tendency exists. The failures of the church are evidence for the problem the mission was designed to address.
 
-The question is whether you can separate the signal from the noise — whether you can hold the mission without inheriting the institution's worst impulses. That's what the remaining hours of this book are about.
+The question is whether you can separate the signal from the noise — whether you can hold the mission without inheriting the institution's worst impulses. That's what the remaining hours are about.
 
 ## Questions to sit with
 


### PR DESCRIPTION
## Summary

- Removes 16 instances of "this book" self-references across 10 chapters (Ch 1, 2, 6, 7, 8, 10, 11, 12, 13, 21)
- Replaced with direct assertions, "these twenty-four hours," "the mission," or simply deleted where the qualifier added nothing
- Preface self-references left intact — the preface naturally introduces itself as a book
- Fixes "seven billion" → "eight billion" in Ch 1 (world population passed 8B in 2022)

These chapters were written before the "no self-references" guideline was established from Marty's Ch 14 review. This pass brings them into alignment.

**Guideline (from Ch 14 revisions):** Don't write "the framework of this book" or "this book rejects." State positions as direct truths — more authoritative, less academic.

## Examples

| Before | After |
|--------|-------|
| "This book takes a clear position:" | "The position is clear:" |
| "Every chapter of this book converges here." | "Every hour converges here." |
| "in the framework of this book" | _(deleted — statement stands on its own)_ |
| "If you remember nothing else from this book" | "If you remember nothing else from these twenty-four hours" |

## Test plan

- [ ] Read each changed line in context — verify the replacement sounds natural
- [ ] Confirm no remaining "this book" references outside the preface
- [ ] Spot-check that no meaning was lost in the edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)