### PR TITLE
Add prev/next chapter navigation to all pages

### DIFF
--- a/manuscript/ch01-god.md
+++ b/manuscript/ch01-god.md
@@ -79,3 +79,7 @@ That last question matters more than you think. Because the mission isn't abstra
 [3]: https://www.esv.org/Job+1/
 [4]: https://www.esv.org/Deuteronomy+30/
 [5]: https://www.esv.org/Matthew+22/
+
+---
+
+[← Preface](preface.html) · [Table of Contents](../) · [Hour 2: The Bible →](ch02-the-bible.html)

--- a/manuscript/ch02-the-bible.md
+++ b/manuscript/ch02-the-bible.md
@@ -74,3 +74,7 @@ God gave you a mind. Use it.
 [5]: https://www.esv.org/Mark+10/
 [6]: https://www.esv.org/1+Corinthians+14/
 [7]: https://www.esv.org/Hebrews+4/
+
+---
+
+[← Hour 1: God](ch01-god.html) · [Table of Contents](../) · [Hour 3: Sin →](ch03-sin.html)

--- a/manuscript/ch03-sin.md
+++ b/manuscript/ch03-sin.md
@@ -117,3 +117,7 @@ The good news is that the test isn't over. You're still choosing. And while the 
 [5]: https://www.esv.org/Matthew+25/
 [6]: https://www.esv.org/Isaiah+5/
 [7]: https://www.esv.org/Matthew+7/
+
+---
+
+[← Hour 2: The Bible](ch02-the-bible.html) · [Table of Contents](../) · [Hour 4: Salvation →](ch04-salvation.html)

--- a/manuscript/ch04-salvation.md
+++ b/manuscript/ch04-salvation.md
@@ -119,3 +119,7 @@ You will be saved by faith. But faith is not lived in isolation. The rest of Par
 [6]: https://www.esv.org/John+21/
 [7]: https://www.esv.org/Matthew+13/
 [8]: https://www.esv.org/Ephesians+2/
+
+---
+
+[← Hour 3: Sin](ch03-sin.html) · [Table of Contents](../) · [Hour 5: Faith →](ch05-faith.html)

--- a/manuscript/ch05-faith.md
+++ b/manuscript/ch05-faith.md
@@ -87,3 +87,7 @@ They do. That's the whole point.
 [5]: https://www.esv.org/Acts+7/
 [6]: https://www.esv.org/Matthew+23/
 [7]: https://www.esv.org/Hebrews+11/
+
+---
+
+[← Hour 4: Salvation](ch04-salvation.html) · [Table of Contents](../) · [Hour 6: The Holy Spirit →](ch06-holy-spirit.html)

--- a/manuscript/ch06-holy-spirit.md
+++ b/manuscript/ch06-holy-spirit.md
@@ -125,3 +125,7 @@ Part II will trace the story — from creation to the early church — so you ca
 [8]: https://www.esv.org/1+Corinthians+12/
 [9]: https://www.esv.org/1+John+4/
 [10]: https://www.esv.org/Galatians+5/
+
+---
+
+[← Hour 5: Faith](ch05-faith.html) · [Table of Contents](../) · [Hour 7: Creation to Abraham →](ch07-creation-to-abraham.html)

--- a/manuscript/ch07-creation-to-abraham.md
+++ b/manuscript/ch07-creation-to-abraham.md
@@ -161,3 +161,7 @@ The mission started in a garden. It nearly ended in a flood. It survived in a co
 [11]: https://www.esv.org/Genesis+16/
 [12]: https://www.esv.org/Genesis+22:2/
 [13]: https://www.esv.org/Genesis+22:12/
+
+---
+
+[← Hour 6: The Holy Spirit](ch06-holy-spirit.html) · [Table of Contents](../) · [Hour 8: Moses and the Law →](ch08-moses-and-the-law.html)

--- a/manuscript/ch08-moses-and-the-law.md
+++ b/manuscript/ch08-moses-and-the-law.md
@@ -157,3 +157,7 @@ The Law was never the solution. It was the setup. It was the necessary stage of 
 [11]: https://www.esv.org/Exodus+32/
 [12]: https://www.esv.org/Numbers+14/
 [13]: https://www.esv.org/Numbers+20/
+
+---
+
+[← Hour 7: Creation to Abraham](ch07-creation-to-abraham.html) · [Table of Contents](../) · [Hour 9: The Prophets →](ch09-the-prophets.html)

--- a/manuscript/ch09-the-prophets.md
+++ b/manuscript/ch09-the-prophets.md
@@ -133,3 +133,7 @@ The Old Testament ends in waiting. The prophets have spoken. The silence has beg
 [10]: https://www.esv.org/Psalm+137/
 [11]: https://www.esv.org/Jeremiah+29/
 [12]: https://www.esv.org/Jeremiah+31/
+
+---
+
+[← Hour 8: Moses and the Law](ch08-moses-and-the-law.html) · [Table of Contents](../) · [Hour 10: Jesus — The Life →](ch10-jesus-the-life.html)

--- a/manuscript/ch10-jesus-the-life.md
+++ b/manuscript/ch10-jesus-the-life.md
@@ -131,3 +131,7 @@ That cost is the next chapter.
 [14]: https://www.esv.org/John+18/
 [15]: https://www.esv.org/Matthew+26:53/
 [16]: https://www.esv.org/John+1:14/
+
+---
+
+[← Hour 9: The Prophets](ch09-the-prophets.html) · [Table of Contents](../) · [Hour 11: Jesus — The Death and Resurrection →](ch11-jesus-death-resurrection.html)

--- a/manuscript/ch11-jesus-death-resurrection.md
+++ b/manuscript/ch11-jesus-death-resurrection.md
@@ -154,3 +154,7 @@ That handoff — from the one who proved it possible to the many who would try t
 [9]: https://www.esv.org/Matthew+28/
 [10]: https://www.esv.org/John+21/
 [11]: https://www.esv.org/Matthew+28:19-20/
+
+---
+
+[← Hour 10: Jesus — The Life](ch10-jesus-the-life.html) · [Table of Contents](../) · [Hour 12: The Early Church →](ch12-the-early-church.html)

--- a/manuscript/ch12-the-early-church.md
+++ b/manuscript/ch12-the-early-church.md
@@ -125,3 +125,7 @@ The story has been told. The question now is whether you will live it.
 [9]: https://www.esv.org/Romans+1/
 [10]: https://www.esv.org/Genesis+12:3/
 [11]: https://www.esv.org/Galatians+2/
+
+---
+
+[← Hour 11: Jesus — The Death and Resurrection](ch11-jesus-death-resurrection.html) · [Table of Contents](../) · [Hour 13: Love God, Love Your Neighbor →](ch13-love-god-love-neighbor.html)

--- a/manuscript/ch13-love-god-love-neighbor.md
+++ b/manuscript/ch13-love-god-love-neighbor.md
@@ -113,3 +113,7 @@ The story has been told. This is where the living starts.
 [4]: https://www.esv.org/Leviticus+19:18/
 [5]: https://www.esv.org/Luke+10/
 [6]: https://www.esv.org/1+Corinthians+13/
+
+---
+
+[← Hour 12: The Early Church](ch12-the-early-church.html) · [Table of Contents](../) · [Hour 14: Prayer →](ch14-prayer.html)

--- a/manuscript/ch14-prayer.md
+++ b/manuscript/ch14-prayer.md
@@ -130,3 +130,7 @@ Then get up. And do the thing that prayer prepared you to do.
 [5]: https://www.esv.org/Luke+6/
 [6]: https://www.esv.org/Matthew+14/
 [7]: https://www.esv.org/Luke+10/
+
+---
+
+[← Hour 13: Love God, Love Your Neighbor](ch13-love-god-love-neighbor.html) · [Table of Contents](../) · [Hour 15: Community →](ch15-community.html)

--- a/manuscript/ch15-community.md
+++ b/manuscript/ch15-community.md
@@ -150,3 +150,7 @@ Two or three. Not two or three thousand. The bar is low. The commitment is high.
 [9]: https://www.esv.org/1+Corinthians+12/
 [10]: https://www.esv.org/Matthew+3/
 [11]: https://www.esv.org/Acts+2/
+
+---
+
+[← Hour 14: Prayer](ch14-prayer.html) · [Table of Contents](../) · [Hour 16: Giving →](ch16-giving.html)

--- a/manuscript/ch16-giving.md
+++ b/manuscript/ch16-giving.md
@@ -130,3 +130,7 @@ The tithe was never the point. The point is whether you're willing to hold your 
 [9]: https://www.esv.org/Exodus+22/
 [10]: https://www.esv.org/Leviticus+25/
 [11]: https://www.esv.org/Ezekiel+18/
+
+---
+
+[← Hour 15: Community](ch15-community.html) · [Table of Contents](../) · [Hour 17: Suffering →](ch17-suffering.html)

--- a/manuscript/ch17-suffering.md
+++ b/manuscript/ch17-suffering.md
@@ -138,3 +138,7 @@ You will encounter suffering you cannot explain. When you do, resist the urge to
 [7]: https://www.esv.org/Psalm+22/
 [8]: https://www.esv.org/Psalm+44/
 [9]: https://www.esv.org/2+Corinthians+1/
+
+---
+
+[← Hour 16: Giving](ch16-giving.html) · [Table of Contents](../) · [Hour 18: Forgiveness →](ch18-forgiveness.html)

--- a/manuscript/ch18-forgiveness.md
+++ b/manuscript/ch18-forgiveness.md
@@ -110,3 +110,7 @@ The point is not perfection. The point is direction. Are you moving toward relea
 [3]: https://www.esv.org/Genesis+50/
 [4]: https://www.esv.org/Ephesians+4/
 [5]: https://www.esv.org/2+Timothy+4/
+
+---
+
+[← Hour 17: Suffering](ch17-suffering.html) · [Table of Contents](../) · [Hour 19: Fake Faith →](ch19-fake-faith.html)

--- a/manuscript/ch19-fake-faith.md
+++ b/manuscript/ch19-fake-faith.md
@@ -109,3 +109,7 @@ Real faith is what remains when you've stripped away the performance, the incent
 [4]: https://www.esv.org/2+Timothy+4/
 [5]: https://www.esv.org/James+2/
 [6]: https://www.esv.org/Galatians+5/
+
+---
+
+[← Hour 18: Forgiveness](ch18-forgiveness.html) · [Table of Contents](../) · [Hour 20: Hard Questions →](ch20-hard-questions.html)

--- a/manuscript/ch20-hard-questions.md
+++ b/manuscript/ch20-hard-questions.md
@@ -175,3 +175,7 @@ The questions don't go away. A faith that requires them to go away is fragile. A
 [10]: https://www.esv.org/Genesis+1/
 [11]: https://www.esv.org/Luke+14/
 [12]: https://www.esv.org/Matthew+12/
+
+---
+
+[← Hour 19: Fake Faith](ch19-fake-faith.html) · [Table of Contents](../) · [Hour 21: Christianity and the World →](ch21-christianity-and-the-world.html)

--- a/manuscript/ch21-christianity-and-the-world.md
+++ b/manuscript/ch21-christianity-and-the-world.md
@@ -102,3 +102,7 @@ The question is whether you can separate the signal from the noise — whether y
 [2]: https://www.esv.org/Matthew+4/
 [3]: https://www.esv.org/Matthew+7/
 [4]: https://www.esv.org/Mark+12/
+
+---
+
+[← Hour 20: Hard Questions](ch20-hard-questions.html) · [Table of Contents](../) · [Hour 22: Reading the Bible →](ch22-reading-the-bible.html)

--- a/manuscript/ch22-reading-the-bible.md
+++ b/manuscript/ch22-reading-the-bible.md
@@ -89,3 +89,7 @@ When a passage doesn't make sense, set it aside and keep reading. The mission �
 [2]: https://www.esv.org/Psalm+23/
 [3]: https://www.esv.org/Revelation+13/
 [4]: https://www.esv.org/Revelation+21/
+
+---
+
+[← Hour 21: Christianity and the World](ch21-christianity-and-the-world.html) · [Table of Contents](../) · [Hour 23: Death and What Comes After →](ch23-death-and-afterlife.html)

--- a/manuscript/ch23-death-and-afterlife.md
+++ b/manuscript/ch23-death-and-afterlife.md
@@ -122,3 +122,7 @@ Death is real. Loss is real. But the story does not end with loss. It ends with 
 [8]: https://www.esv.org/Philippians+2/
 [9]: https://www.esv.org/1+John+4/
 [10]: https://www.esv.org/Revelation+21/
+
+---
+
+[← Hour 22: Reading the Bible](ch22-reading-the-bible.html) · [Table of Contents](../) · [Hour 24: The Decision →](ch24-the-decision.html)

--- a/manuscript/ch24-the-decision.md
+++ b/manuscript/ch24-the-decision.md
@@ -119,3 +119,7 @@ Choose life. Today. And tomorrow. And the day after that.
 * The mission asks whether humanity can get this right. Your part of the answer is your life. What is your life saying?
 
 [1]: https://www.esv.org/Deuteronomy+30/
+
+---
+
+[← Hour 23: Death and What Comes After](ch23-death-and-afterlife.html) · [Table of Contents](../) · [Epilogue: Now Go →](epilogue.html)

--- a/manuscript/epilogue.md
+++ b/manuscript/epilogue.md
@@ -13,3 +13,7 @@ This is an invitation.
 **Join the community.** We are gathering on [Discord](https://discord.gg/2xdup499t). Come as you are. Bring your doubt. Bring your questions. Bring your willingness to do the hard work.
 
 **Support the mission.** If you believe humanity is worth saving — if the victory conditions are worth pursuing across generations — then put something behind that belief. We are raising funds to build God's kingdom on Earth, openly and transparently: [gofundme.com/f/open-source-society](https://www.gofundme.com/f/open-source-society)
+
+---
+
+[← Hour 24: The Decision](ch24-the-decision.html) · [Table of Contents](../)

--- a/manuscript/preface.md
+++ b/manuscript/preface.md
@@ -13,3 +13,7 @@ This book exists to explain what faith in God really means, over 24 chapters you
 Once you’ve read this book, go read the Bible for yourself, from cover to cover, and see whether you reach the same conclusions. Many people will tell you the Bible is too difficult for a mere human like you to understand. Those people are quite frankly insulting your intelligence, and they are scared of the responsibilities that come with the inconvenient truth.
 
 Like Neo meeting Morpheus for the first time, you can choose now to take the blue pill and toss this book in the trash. But if you’re game to try the red pill, read on.
+
+---
+
+[Table of Contents](../) · [Hour 1: God →](ch01-god.html)


### PR DESCRIPTION
## Summary

- Adds sequential navigation links at the bottom of all 26 reading pages (preface through epilogue)
- Format: `← Previous: Title · Table of Contents · Next: Title →`
- Preface has no previous link; epilogue has no next link; all others have both
- Skips part divider pages (part1-4) — readers navigate directly between chapters
- Improves reading experience on GitHub Pages: readers can move through the book sequentially without returning to the index each time

## Test plan

- [ ] Verify all 26 pages render correctly on GitHub Pages
- [ ] Click through a few prev/next links to confirm they resolve
- [ ] Verify Table of Contents link returns to index

🤖 Generated with [Claude Code](https://claude.com/claude-code)