### PR TITLE
Fix Q&A formatting — separate lines in chapter headers

### DIFF
--- a/manuscript/ch01-god.md
+++ b/manuscript/ch01-god.md
@@ -1,6 +1,7 @@
 # Hour 1: God
 
 Q: Why did God create humanity?
+
 A: To prove — to Satan, and to ourselves — that we can get this right.
 
 ## Commentary

--- a/manuscript/ch02-the-bible.md
+++ b/manuscript/ch02-the-bible.md
@@ -1,6 +1,7 @@
 # Hour 2: The Bible
 
 Q: Is the Bible the word of God?
+
 A: Yes. But that doesn't mean what most people think it means.
 
 ## Commentary

--- a/manuscript/ch03-sin.md
+++ b/manuscript/ch03-sin.md
@@ -1,6 +1,7 @@
 # Hour 3: Sin
 
 Q: Am I a sinner?
+
 A: Yes. So is everyone you've ever met. The question is what you do about it.
 
 ## Commentary

--- a/manuscript/ch04-salvation.md
+++ b/manuscript/ch04-salvation.md
@@ -1,6 +1,7 @@
 # Hour 4: Salvation
 
 Q: If everyone sins, is anyone saved?
+
 A: Yes. Salvation is not a reward for the perfect — it is the process of choosing the mission over yourself, again and again, with help.
 
 ## Commentary

--- a/manuscript/ch05-faith.md
+++ b/manuscript/ch05-faith.md
@@ -1,6 +1,7 @@
 # Hour 5: Faith
 
 Q: What does it mean to have faith?
+
 A: It means choosing to act on what you believe, especially when it costs you something.
 
 ## Commentary

--- a/manuscript/ch06-holy-spirit.md
+++ b/manuscript/ch06-holy-spirit.md
@@ -1,6 +1,7 @@
 # Hour 6: The Holy Spirit
 
 Q: What is the Holy Spirit?
+
 A: God's power, given to the early church to launch the mission. Not a hotline for personal guidance today.
 
 ## Commentary

--- a/manuscript/ch07-creation-to-abraham.md
+++ b/manuscript/ch07-creation-to-abraham.md
@@ -1,6 +1,7 @@
 # Hour 7: Creation to Abraham
 
 Q: What happened between "In the beginning" and the start of Israel?
+
 A: God created, humanity failed, God refused to give up, and one man said yes.
 
 ## Commentary

--- a/manuscript/ch08-moses-and-the-law.md
+++ b/manuscript/ch08-moses-and-the-law.md
@@ -1,6 +1,7 @@
 # Hour 8: Moses and the Law
 
 Q: Why did God give rules He knew people would break?
+
 A: Because early humanity didn't know how to conduct themselves. Rules are how you teach children — and humanity was a child. You internalize the rules, you grow up, and eventually you don't need someone handing them to you anymore. Humanity is in adulthood now.
 
 ## Commentary

--- a/manuscript/ch09-the-prophets.md
+++ b/manuscript/ch09-the-prophets.md
@@ -1,6 +1,7 @@
 # Hour 9: The Prophets
 
 Q: If God stopped intervening directly, how did He communicate with Israel?
+
 A: Through people who told the truth no one wanted to hear.
 
 ## Commentary

--- a/manuscript/ch10-jesus-the-life.md
+++ b/manuscript/ch10-jesus-the-life.md
@@ -1,6 +1,7 @@
 # Hour 10: Jesus — The Life
 
 Q: Who was Jesus?
+
 A: The person who showed humanity what faithfulness looks like — lived, not legislated.
 
 ## Commentary

--- a/manuscript/ch11-jesus-death-resurrection.md
+++ b/manuscript/ch11-jesus-death-resurrection.md
@@ -1,6 +1,7 @@
 # Hour 11: Jesus — The Death and Resurrection
 
 Q: Why did Jesus have to die?
+
 A: He didn't have to. He chose to. And that choice is the point.
 
 ## Commentary

--- a/manuscript/ch12-the-early-church.md
+++ b/manuscript/ch12-the-early-church.md
@@ -1,6 +1,7 @@
 # Hour 12: The Early Church
 
 Q: What happened after Jesus left?
+
 A: A handful of ordinary people tried to live the mission. They failed constantly and changed the world anyway.
 
 ## Commentary

--- a/manuscript/ch13-love-god-love-neighbor.md
+++ b/manuscript/ch13-love-god-love-neighbor.md
@@ -1,6 +1,7 @@
 # Hour 13: Love God, Love Your Neighbor
 
 Q: If you had to reduce all of Christianity to one sentence, what would it be?
+
 A: Love God, love your neighbor. Everything else is commentary.
 
 ## Commentary

--- a/manuscript/ch14-prayer.md
+++ b/manuscript/ch14-prayer.md
@@ -1,6 +1,7 @@
 # Hour 14: Prayer
 
 Q: Does prayer work?
+
 A: Define "work." If you mean does God grant requests — read on. If you mean does prayer change you — it can. And that's the point.
 
 ## Commentary

--- a/manuscript/ch15-community.md
+++ b/manuscript/ch15-community.md
@@ -1,6 +1,7 @@
 # Hour 15: Community
 
 Q: Do I need to go to church?
+
 A: You need community. Whether that happens in a church building is between you and the people you choose to walk with.
 
 ## Commentary

--- a/manuscript/ch16-giving.md
+++ b/manuscript/ch16-giving.md
@@ -1,6 +1,7 @@
 # Hour 16: Giving
 
 Q: What's an appropriate tithe to the church?
+
 A: Wrong question. The right question is: what are you holding back, and why?
 
 ## Commentary

--- a/manuscript/ch17-suffering.md
+++ b/manuscript/ch17-suffering.md
@@ -1,6 +1,7 @@
 # Hour 17: Suffering
 
 Q: Why does God allow suffering?
+
 A: Pain gives the test meaning and makes the mission real.
 
 ## Commentary

--- a/manuscript/ch18-forgiveness.md
+++ b/manuscript/ch18-forgiveness.md
@@ -1,6 +1,7 @@
 # Hour 18: Forgiveness
 
 Q: How many times do I have to forgive someone?
+
 A: Every time. That's the answer you don't want.
 
 ## Commentary

--- a/manuscript/ch19-fake-faith.md
+++ b/manuscript/ch19-fake-faith.md
@@ -1,6 +1,7 @@
 # Hour 19: Fake Faith
 
 Q: How do I know if my faith is real?
+
 A: If it costs you nothing, it probably isn't.
 
 ## Commentary

--- a/manuscript/ch20-hard-questions.md
+++ b/manuscript/ch20-hard-questions.md
@@ -1,6 +1,7 @@
 # Hour 20: Hard Questions
 
 Q: What about all the things Christianity can't explain?
+
 A: Honest faith doesn't require answers to every question. It requires honesty about which ones you're avoiding.
 
 ## Commentary

--- a/manuscript/ch21-christianity-and-the-world.md
+++ b/manuscript/ch21-christianity-and-the-world.md
@@ -1,6 +1,7 @@
 # Hour 21: Christianity and the World
 
 Q: If the mission is so clear, why has the church gotten it so wrong?
+
 A: Because the institution chose power over the mission — and it's been doing it for seventeen centuries.
 
 ## Commentary

--- a/manuscript/ch22-reading-the-bible.md
+++ b/manuscript/ch22-reading-the-bible.md
@@ -1,6 +1,7 @@
 # Hour 22: Reading the Bible
 
 Q: Where do I even start with the Bible?
+
 A: With the story. The Bible tells one story across sixty-six books: humanity growing up. Once you see that arc, everything else falls into place.
 
 ## Commentary

--- a/manuscript/ch23-death-and-afterlife.md
+++ b/manuscript/ch23-death-and-afterlife.md
@@ -1,6 +1,7 @@
 # Hour 23: Death and What Comes After
 
 Q: What happens when we die?
+
 A: The honest answer is that Christians disagree. But the Bible's consistent picture is that death is not the end of accountability — and the measure is not what you believed but how you loved.
 
 ## Commentary

--- a/manuscript/ch24-the-decision.md
+++ b/manuscript/ch24-the-decision.md
@@ -1,6 +1,7 @@
 # Hour 24: The Decision
 
 Q: After twenty-three hours, what now?
+
 A: You decide. That was always the point.
 
 ## Commentary


### PR DESCRIPTION
## Summary
- Added a blank line between the Q and A lines at the top of each chapter
- In Markdown, consecutive lines without a blank line render as a single paragraph — this caused the Q&A to display inline on the website instead of on separate lines
- All 24 chapters fixed

## Before
```
Q: Why did God create humanity? A: To prove — to Satan, and to ourselves — that we can get this right.
```

## After
```
Q: Why did God create humanity?

A: To prove — to Satan, and to ourselves — that we can get this right.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)