### PR TITLE
Fresh-eyes editorial pass — references, voice, and tone

### DIFF
--- a/manuscript/ch06-holy-spirit.md
+++ b/manuscript/ch06-holy-spirit.md
@@ -19,7 +19,7 @@ In the Old Testament, the Spirit appears selectively. It fills specific people f
 > Now the Spirit of the LORD departed from Saul, and a harmful spirit from the LORD tormented him.
 — [1 Samuel 16:14 ESV][4]
 
-The Spirit was God's tool — deployed with precision, withdrawn at will. It was not a standing resource available to everyone. It was power given to specific people for specific jobs within God's unfolding plan.
+The Spirit was God's tool — deployed with precision, withdrawn at will. It was not a standing resource available to everyone. It was power given to specific people for specific jobs within the unfolding story.
 
 ## Pentecost: the Spirit and the early church
 

--- a/manuscript/ch07-creation-to-abraham.md
+++ b/manuscript/ch07-creation-to-abraham.md
@@ -122,7 +122,7 @@ The story reaches its sharpest point in Genesis 22.
 
 God asks Abraham to sacrifice the son he waited decades for. The son through whom the entire covenant was supposed to continue. The son who represents everything God promised.
 
-Abraham obeys. He binds Isaac, lays him on the altar, raises the knife. And God stops him.
+Abraham goes through with it. He binds Isaac, lays him on the altar, raises the knife. And God stops him.
 
 > "Do not lay your hand on the boy or do anything to him, for now I know that you fear God, seeing you have not withheld your son, your only son, from me."
 — [Genesis 22:12 ESV][13]

--- a/manuscript/ch08-moses-and-the-law.md
+++ b/manuscript/ch08-moses-and-the-law.md
@@ -48,7 +48,7 @@ God parts the sea. Israel walks through on dry ground. The Egyptian army follows
 
 Here is the question this demands: if God could do *that*, why doesn't He intervene like that today?
 
-The answer is core tenet #2. God's direct interventions had a defined arc — a progression building toward Jesus. The Exodus was part of that arc. God was building a people, establishing a covenant nation, and setting the stage for everything that would follow. These interventions were not random acts of power. They were steps in a plan that had a beginning, a middle, and an end. The end came with Christ. After that, humanity has what it needs. The test is ours to pass or fail without the sea parting for us.
+The answer is core tenet #2. God's direct interventions had a defined arc — a progression building toward Jesus. The Exodus was part of that arc. God was building a people, establishing a covenant nation, and setting the stage for everything that would follow. These interventions were not random acts of power. They were steps in a trajectory that had a beginning, a middle, and an end. The end came with Christ. After that, humanity has what it needs. The test is ours to pass or fail without the sea parting for us.
 
 That might not satisfy you. It shouldn't be easy. The distance between a God who parts oceans and a God who watches in silence is the central tension of the entire Bible. We will come back to it.
 
@@ -143,7 +143,7 @@ The Law was never the solution. It was the setup. It was the necessary stage of 
 
 * God gave the Law knowing people would break it. What does that tell you about the purpose of rules — in religion, and in your own life?
 * The Israelites wanted to go back to slavery rather than face the unknown. Where in your life have you chosen a familiar cage over an uncertain freedom?
-* Moses served faithfully for forty years and was denied entry to the Promised Land for one act of disobedience. Is that fair? Does "fair" matter?
+* Moses served faithfully for forty years and was denied entry to the Promised Land for one moment of unfaithfulness. Is that fair? Does "fair" matter?
 
 [1]: https://www.esv.org/Exodus+1/
 [2]: https://www.esv.org/Exodus+3/

--- a/manuscript/ch09-the-prophets.md
+++ b/manuscript/ch09-the-prophets.md
@@ -23,7 +23,7 @@ Saul is the first king. He starts well and ends in paranoia, jealousy, and disob
 
 The Bible does not flinch from this. The greatest king in Israel's history — the one from whose line Jesus would come — committed acts that should disqualify him from any position of moral authority. And the prophet Nathan walked into the palace and made David condemn himself.
 
-Nathan didn't accuse David directly. He told him a story: a rich man with enormous flocks stole the one beloved lamb of a poor man — the only thing the poor man had, a lamb he'd raised like a daughter. David was furious. "The man who has done this deserves to die!" ([2 Samuel 12:5][4a]). Then Nathan delivered the line that echoes through every chapter of prophetic literature:
+Nathan didn't accuse David directly. He told him a story: a rich man with enormous flocks stole the one beloved lamb of a poor man — the only thing the poor man had, a lamb he'd raised like a daughter. David was furious. "The man who has done this deserves to die!" ([2 Samuel 12:5][4]). Then Nathan delivered the line that echoes through every chapter of prophetic literature:
 
 > Nathan said to David, "You are the man!"
 — [2 Samuel 12:7 ESV][4]
@@ -124,8 +124,7 @@ The Old Testament ends in waiting. The prophets have spoken. The silence has beg
 [1]: https://www.esv.org/1+Samuel+8/
 [2]: https://www.esv.org/1+Samuel+13:14/
 [3]: https://www.esv.org/2+Samuel+11/
-[4]: https://www.esv.org/2+Samuel+12:7/
-[4a]: https://www.esv.org/2+Samuel+12:5/
+[4]: https://www.esv.org/2+Samuel+12/
 [5]: https://www.esv.org/1+Kings+11/
 [6]: https://www.esv.org/Amos+5/
 [7]: https://www.esv.org/Hosea+3/

--- a/manuscript/ch10-jesus-the-life.md
+++ b/manuscript/ch10-jesus-the-life.md
@@ -71,7 +71,7 @@ These parables are not illustrations. They are the mission statement. Love the p
 Jesus reserved his sharpest criticism not for sinners but for the religious establishment.
 
 > Woe to you, scribes and Pharisees, hypocrites! For you tithe mint and dill and cumin, and have neglected the weightier matters of the law: justice and mercy and faithfulness.
-— [Matthew 23:23 ESV][13]
+— [Matthew 23:23 ESV][11]
 
 The Pharisees tithed their spice racks. They counted out one-tenth of their herbs to comply with the Law's requirement. And while they were measuring cumin, they ignored the people who needed justice, mercy, and faithfulness. They had perfected the performance of religion and abandoned its purpose.
 
@@ -86,9 +86,9 @@ Equally important is what Jesus did not do.
 He did not establish an earthly kingdom. Israel expected a messiah who would overthrow Rome, restore the monarchy, and reign from David's throne. Jesus refused that role so consistently that people who followed him for the miracles and the food eventually left because he wouldn't be the political leader they wanted.
 
 > Jesus answered, "My kingdom is not of this world. If my kingdom were of this world, my servants would have been fighting, that I might not be handed over to the Jews. But my kingdom is not from the world."
-— [John 18:36 ESV][14]
+— [John 18:36 ESV][12]
 
-He did not use his gifts to protect himself. He healed others but accepted his own suffering. When arrested, he told his disciples he could have asked God for twelve legions of angels ([Matthew 26:53][15]) — but chose the cross instead.
+He did not use his gifts to protect himself. He healed others but accepted his own suffering. When arrested, he told his disciples he could have asked God for twelve legions of angels ([Matthew 26:53][13]) — but chose the cross instead.
 
 He did not condemn the people the religious leaders condemned. He went to the tax collectors, the prostitutes, the unclean, the marginalized — the people religion had failed — and he ate with them, talked with them, healed them, and told them they mattered.
 
@@ -101,7 +101,7 @@ The Law showed what faithfulness looks like on paper. Jesus showed what it looks
 John's gospel captured this with a single line:
 
 > And the Word became flesh and dwelt among us, and we have seen his glory, glory as of the only Son from the Father, full of grace and truth.
-— [John 1:14 ESV][16]
+— [John 1:14 ESV][14]
 
 Mainstream theology reads this as divine incarnation — God becoming human. But there is another way to hear it. The Word — God's message, the covenant, the mission that had been carved on stone, spoken through prophets, argued over by scholars — became flesh. It was lived. For the first time, someone didn't just teach the word or preach it or legislate it. Someone embodied it. The word on the tablet became a life.
 
@@ -127,11 +127,10 @@ That cost is the next chapter.
 [8]: https://www.esv.org/Matthew+19/
 [9]: https://www.esv.org/Luke+10/
 [10]: https://www.esv.org/Luke+15/
-[11]: https://www.esv.org/Matthew+25/
-[13]: https://www.esv.org/Matthew+23/
-[14]: https://www.esv.org/John+18/
-[15]: https://www.esv.org/Matthew+26:53/
-[16]: https://www.esv.org/John+1:14/
+[11]: https://www.esv.org/Matthew+23/
+[12]: https://www.esv.org/John+18/
+[13]: https://www.esv.org/Matthew+26:53/
+[14]: https://www.esv.org/John+1:14/
 
 ---
 

--- a/manuscript/ch14-prayer.md
+++ b/manuscript/ch14-prayer.md
@@ -2,7 +2,7 @@
 
 Q: Does prayer work?
 
-A: Define "work." If you mean does God grant requests — read on. If you mean does prayer change you — it can. And that's the point.
+A: Define "work." If you mean does God grant requests — read on. If you mean does prayer change you — yes. And that's the point.
 
 ## Commentary
 

--- a/manuscript/ch24-the-decision.md
+++ b/manuscript/ch24-the-decision.md
@@ -82,7 +82,7 @@ Not abstractions. Measurable conditions. Here is what "love your neighbor" looks
 
 **Education without gatekeepers.** No pay-to-win private schools that guarantee advantage to the wealthy. No overpriced school districts that sort children by their parents' income before they are old enough to read. Knowledge is not a commodity. The victory condition is a world where the quality of your education has nothing to do with the wealth of your family — where every child has equal access to grow into their full capacity.
 
-These are not utopian fantasies. They are the logical conclusions of "love your neighbor as yourself." Every one of them is measurable. Every one of them is achievable — not today, not this generation, not for many generations. But each act of love, each stand for justice, each sacrifice that chooses others over self moves humanity closer.
+These are not utopian fantasies. They are the logical conclusions of "love your neighbor as yourself." Every one of them is measurable. Every one of them is achievable — not today, not this generation, perhaps not for many generations. But each act of love, each stand for justice, each sacrifice that chooses others over self moves humanity closer.
 
 And the promise is that the endpoint is real — that one day the mission is complete, the celebration happens, and every person who carried it across every generation is present for it.
 

--- a/manuscript/ch24-the-decision.md
+++ b/manuscript/ch24-the-decision.md
@@ -22,7 +22,7 @@ Everything has been building to this hour. Not to a conclusion — to a decision
 
 ## What growing up looks like
 
-The maturation metaphor has run through the entire book. The Law was childhood rules. The prophets were the voice saying "you're ready to grow." Jesus was the proof that grown-up faithfulness is possible. The mission is what you do when you've internalized the principles and don't need someone listing the rules.
+The maturation metaphor has run through every hour. The Law was childhood rules. The prophets were the voice saying "you're ready to grow." Jesus was the proof that grown-up faithfulness is possible. The mission is what you do when you've internalized the principles and don't need someone listing the rules.
 
 So what does spiritual maturity actually look like? Not what the church usually measures — attendance, tithing records, committee participation, years of membership. Those are metrics for an institution. Spiritual maturity is measured differently.
 
@@ -82,7 +82,7 @@ Not abstractions. Measurable conditions. Here is what "love your neighbor" looks
 
 **Education without gatekeepers.** No pay-to-win private schools that guarantee advantage to the wealthy. No overpriced school districts that sort children by their parents' income before they are old enough to read. Knowledge is not a commodity. The victory condition is a world where the quality of your education has nothing to do with the wealth of your family — where every child has equal access to grow into their full capacity.
 
-These are not utopian fantasies. They are the logical conclusions of "love your neighbor as yourself." Every one of them is measurable. Every one of them is achievable — not today, not this generation, perhaps not for many generations. But each act of love, each stand for justice, each sacrifice that chooses others over self moves humanity closer.
+These are not utopian fantasies. They are the logical conclusions of "love your neighbor as yourself." Every one of them is measurable. Every one of them is achievable — not today, not this generation, not for many generations. But each act of love, each stand for justice, each sacrifice that chooses others over self moves humanity closer.
 
 And the promise is that the endpoint is real — that one day the mission is complete, the celebration happens, and every person who carried it across every generation is present for it.
 
@@ -120,6 +120,8 @@ Choose life. Today. And tomorrow. And the day after that.
 * The mission asks whether humanity can get this right. Your part of the answer is your life. What is your life saying?
 
 [1]: https://www.esv.org/Deuteronomy+30/
+[2]: https://www.esv.org/Revelation+21/
+[3]: https://www.esv.org/Matthew+25/
 
 ---
 


### PR DESCRIPTION
## Summary
Marty asked me to re-read the book with fresh eyes and propose edits. I audited all 24 chapters + epilogue against the current voice guidelines. Seven chapters needed fixes; the rest are clean.

## Broken references (HIGH priority)
- **Ch 24**: `[2]` (Revelation 21:3-4) and `[3]` (Matthew 25:35) were used in the victory conditions section but had no URL definitions — rendering as broken links on the site
- **Ch 10**: Orphan `[11]` (Matthew 25) was a leftover from when Sheep/Goats was moved to Ch 23. Removed and renumbered `[13]-[16]` → `[11]-[14]`
- **Ch 9**: Non-standard `[4a]` reference replaced — both 2 Samuel 12:5 and 12:7 now share `[4]` pointing to the full chapter

## Voice guideline fixes
- **Ch 24**: "entire book" → "every hour" (no self-references)
- **Ch 7**: "Abraham obeys" → "Abraham goes through with it" (no obedience language)
- **Ch 8**: "disobedience" → "unfaithfulness", "steps in a plan" → "steps in a trajectory"
- **Ch 6**: "God's unfolding plan" → "the unfolding story"

## Tone tightening
- **Ch 24**: "perhaps not for many generations" → "not for many generations"
- **Ch 14**: Answer line "it can" → "yes" — direct over hedging

## Chapters reviewed, no changes needed
Ch 1-4 (already revised by Marty), Ch 5, 11, 12, 13, 15, 16, 17, 18, 19, 20, 21, 22, 23, epilogue

## Items I noted but left alone
- Ch 20 lines 43/45: "may reflect" / "may have attributed" — hedges on speculative OT violence framing, appropriate in context
- Ch 20 line 149: forward reference to "victory conditions from Hour 24" — works as a promise to the reader
- Ch 3 line 34: "the human author of this book" — Marty's deliberate personal accountability line, not the academic self-reference pattern
- Ch 9 line 65: Isaiah "whether you read it as..." — honest about interpretive uncertainty, not hedging
- Forward references ("next chapter", "few chapters away") throughout — structural bridges, clearly intentional

🤖 Generated with [Claude Code](https://claude.com/claude-code)