### PR TITLE
Remove core tenet references from chapters

### DIFF
--- a/manuscript/ch06-holy-spirit.md
+++ b/manuscript/ch06-holy-spirit.md
@@ -62,7 +62,7 @@ We have the complete Bible — sixty-six books recording everything God wanted h
 
 The early apostles had none of this. They needed the Spirit because they were building the plane while flying it. We have the plane. It's built. The instructions are in the seat-back pocket.
 
-This doesn't mean God abandoned us. It means God gave us everything we need and trusts us to use it. Core tenet #1: God is the creator, not the puppeteer. The mission is ours to execute. God provided the tools — Scripture, the example of Jesus, the capacity to reason, and each other — and stepped back.
+This doesn't mean God abandoned us. It means God gave us everything we need and trusts us to use it. God is the creator, not the puppeteer. The mission is ours to execute. God provided the tools — Scripture, the example of Jesus, the capacity to reason, and each other — and stepped back.
 
 That is not abandonment. That is the test.
 

--- a/manuscript/ch07-creation-to-abraham.md
+++ b/manuscript/ch07-creation-to-abraham.md
@@ -64,7 +64,7 @@ God's response was the flood. Every living thing destroyed except Noah, his fami
 
 Here is where it gets uncomfortable: how does a flood that kills almost everyone square with a God who values free will and human agency?
 
-The answer is that the Old Testament records a period when God was actively intervening. Core tenet #2 says God's direct interventions had a defined arc. The flood is part of that arc — a point early in the story when the experiment had gone so wrong that continuing without intervention would have meant the permanent triumph of the prosecution's case. God didn't destroy the world out of spite. God preserved the one family that hadn't abandoned the mission entirely, and started again.
+The answer is that the Old Testament records a period when God was actively intervening. God's direct interventions had a defined arc — a progression building toward Jesus. The flood is part of that arc — a point early in the story when the experiment had gone so wrong that continuing without intervention would have meant the permanent triumph of the prosecution's case. God didn't destroy the world out of spite. God preserved the one family that hadn't abandoned the mission entirely, and started again.
 
 But notice what happens next. After the flood, after the rainbow, after the covenant, Noah plants a vineyard. He makes wine. He gets drunk and passes out naked in his tent ([Genesis 9:20-21][5]). The first thing humanity does after a global reset is sin again.
 

--- a/manuscript/ch08-moses-and-the-law.md
+++ b/manuscript/ch08-moses-and-the-law.md
@@ -48,7 +48,7 @@ God parts the sea. Israel walks through on dry ground. The Egyptian army follows
 
 Here is the question this demands: if God could do *that*, why doesn't He intervene like that today?
 
-The answer is core tenet #2. God's direct interventions had a defined arc — a progression building toward Jesus. The Exodus was part of that arc. God was building a people, establishing a covenant nation, and setting the stage for everything that would follow. These interventions were not random acts of power. They were steps in a trajectory that had a beginning, a middle, and an end. The end came with Christ. After that, humanity has what it needs. The test is ours to pass or fail without the sea parting for us.
+The answer is the same one from the flood in Hour 7. God's direct interventions had a defined arc — a progression building toward Jesus. The Exodus was part of that arc. God was building a people, establishing a covenant nation, and setting the stage for everything that would follow. These interventions were not random acts of power. They were steps in a trajectory that had a beginning, a middle, and an end. The end came with Christ. After that, humanity has what it needs. The test is ours to pass or fail without the sea parting for us.
 
 That might not satisfy you. It shouldn't be easy. The distance between a God who parts oceans and a God who watches in silence is the central tension of the entire Bible. We will come back to it.
 


### PR DESCRIPTION
## Summary
Core tenets are author-internal reference material (stored in `reference/core-tenets.md`). They guide our writing but shouldn't be visible to readers, who have no context for "core tenet #1" or "#2".

Three instances found and fixed:
- **Ch 6 line 65**: "Core tenet #1: God is the creator, not the puppeteer" → "God is the creator, not the puppeteer" — just dropped the label, the statement stands on its own
- **Ch 7 line 67**: "Core tenet #2 says God's direct interventions had a defined arc" → stated directly with added context ("a progression building toward Jesus")
- **Ch 8 line 51**: "The answer is core tenet #2" → "The answer is the same one from the flood in Hour 7" — references the earlier chapter instead of the internal document

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)