### PR TITLE
Remove gender-specific pronouns for God

### DIFF
--- a/manuscript/ch01-god.md
+++ b/manuscript/ch01-god.md
@@ -19,7 +19,7 @@ At one point, God _regretted_ creating us. That's not the language of a detached
 
 ## Why did God create us?
 
-Not as pets. Not for entertainment. And not because God needed someone to worship Him.
+Not as pets. Not for entertainment. And not because God needed worshippers.
 
 God created humanity with a mission, a test. Think of it this way: God has a vision for what we could be — a species that overcomes its fears and vices to sustainably manage the world we're given. Can _we_ become that species?
 - If Earth becomes uninhabitable, game over.
@@ -74,7 +74,7 @@ Simple to understand. Extraordinarily difficult to live. And that tension betwee
 
 ## Questions to sit with
 
-* If God experiences emotions like we do, what does that change about how you relate to Him?
+* If God experiences emotions like we do, what does that change about how you relate to God?
 * Do you believe humanity's problems are solvable, or have you already decided we're doomed? What does your answer say about your faith?
 * When you hear "love your neighbor as yourself," who is the neighbor you find hardest to love?
 

--- a/manuscript/ch04-salvation.md
+++ b/manuscript/ch04-salvation.md
@@ -41,7 +41,7 @@ Hour 3 established that every person falls short. The standard is love God, love
 
 Jesus bridges that gap. But not the way most churches explain it.
 
-The traditional framing says Jesus took the punishment for your sins — that God's justice demanded blood, and Jesus paid the price so you wouldn't have to. This is substitutionary atonement, and it has dominated Western Christianity for centuries. But it makes God a creditor and the cross a transaction. A God who requires the torture and death of his own prophet to satisfy his own rules is not a God of love. That is a God of accounting.
+The traditional framing says Jesus took the punishment for your sins — that God's justice demanded blood, and Jesus paid the price so you wouldn't have to. This is substitutionary atonement, and it has dominated Western Christianity for centuries. But it makes God a creditor and the cross a transaction. A God who demands a chosen prophet's torture and death to satisfy self-imposed rules is not a God of love. That is a God of accounting.
 
 Here is what Jesus actually did: he lived the mission without faltering. That's it. That's everything.
 

--- a/manuscript/ch07-creation-to-abraham.md
+++ b/manuscript/ch07-creation-to-abraham.md
@@ -107,7 +107,7 @@ God's promise to Abraham is the foundation of everything that follows in the Old
 > And I will establish my covenant between me and you and your offspring after you throughout their generations for an everlasting covenant, to be God to you and to your offspring after you.
 — [Genesis 17:7 ESV][8]
 
-This is not a transaction. It's a covenant — a binding commitment from God to Abraham and his descendants. Through this one family, God would build a people. Through that people, God would reveal His character, establish His law, and eventually send Jesus. Every chapter from here to the Gospels flows through this promise.
+This is not a transaction. It's a covenant — a binding commitment from God to Abraham and his descendants. Through this one family, God would build a people. Through that people, God would reveal God's character, establish the Law, and eventually send Jesus. Every chapter from here to the Gospels flows through this promise.
 
 But Abraham wasn't perfect. He lied about his wife being his sister — twice ([Genesis 12:13][9], [Genesis 20:2][10]). He slept with Hagar because he and Sarah doubted God's promise of a son ([Genesis 16][11]). He was a man who said yes to God and then stumbled, repeatedly, like every person who has ever tried to live faithfully.
 

--- a/manuscript/ch09-the-prophets.md
+++ b/manuscript/ch09-the-prophets.md
@@ -1,6 +1,6 @@
 # Hour 9: The Prophets
 
-Q: If God stopped intervening directly, how did He communicate with Israel?
+Q: If God stopped intervening directly, how did God communicate with Israel?
 
 A: Through people who told the truth no one wanted to hear.
 

--- a/manuscript/ch14-prayer.md
+++ b/manuscript/ch14-prayer.md
@@ -10,7 +10,7 @@ Prayer is the most misunderstood practice in Christianity. Not because it's comp
 
 The assumption: God is listening and might intervene.
 
-But here is the reality: God gave humanity everything we need — the example of Jesus, the record of Scripture, the capacity to reason — and stepped back. He is not adjusting outcomes. He is not granting requests. He is not running a cosmic customer service line with hold music and a callback option.
+But here is the reality: God gave humanity everything we need — the example of Jesus, the record of Scripture, the capacity to reason — and stepped back. Not adjusting outcomes. Not granting requests. Not running a cosmic customer service line with hold music and a callback option.
 
 So what is prayer?
 
@@ -67,7 +67,7 @@ Jesus asked to be spared. He didn't want to die. He wasn't stoic about it — Ma
 
 God didn't answer. The cup did not pass. Jesus went to the cross.
 
-This is the central prayer of Christianity, and it was not granted. If you build your understanding of prayer on the idea that God hears and responds to requests, you have to explain why he didn't respond to this one. Why would God ignore the prayer of the person who carried the mission most faithfully?
+This is the central prayer of Christianity, and it was not granted. If you build your understanding of prayer on the idea that God hears and responds to requests, you have to explain why God didn't respond to this one. Why would God ignore the prayer of the person who carried the mission most faithfully?
 
 The answer: God wasn't ignoring the prayer. The prayer was never about changing the outcome. The prayer was about Jesus being honest about what he faced, naming his fear, and then choosing the mission anyway.
 
@@ -121,7 +121,7 @@ Then get up. And do the thing that prayer prepared you to do.
 ## Questions to sit with
 
 * When was the last time you prayed and were genuinely honest — not performing, not reciting, but telling the truth about where you are?
-* Jesus prayed to be spared and wasn't. Has your understanding of prayer been built on the expectation that God will give you what you ask for? What happens to your faith if he doesn't?
+* Jesus prayed to be spared and wasn't. Has your understanding of prayer been built on the expectation that God will give you what you ask for? What happens to your faith when the answer is no?
 * What would change in your daily life if you spent two minutes each morning in honest self-examination instead of scrolling your phone?
 
 [1]: https://www.esv.org/Matthew+6/


### PR DESCRIPTION
## Summary

Marty requested removing all gender-specific pronouns referring to God from the manuscript. Audited all 24 chapters + epilogue + preface.

- **10 pronouns** (he/him/his) referring to God found across **5 files** (ch01, ch04, ch07, ch09, ch14)
- **19 chapters + epilogue + preface** were already gender-neutral — no changes needed
- **ESV blockquotes** left unchanged (direct Scripture citations — changing them would be misquoting)

### Changes by chapter

| Chapter | Change |
|---------|--------|
| Ch 1 (God) | "worship Him" → "needed worshippers"; "relate to Him" → "relate to God" |
| Ch 4 (Salvation) | "his own prophet to satisfy his own rules" → "a chosen prophet's torture and death to satisfy self-imposed rules" |
| Ch 7 (Creation to Abraham) | "reveal His character, establish His law" → "reveal God's character, establish the Law" |
| Ch 9 (The Prophets) | "how did He communicate" → "how did God communicate" |
| Ch 14 (Prayer) | Three "He is not..." → "Not adjusting... Not granting... Not running..."; "why he didn't respond" → "why God didn't respond"; "if he doesn't" → "when the answer is no" |

### Note on ESV quotes

Several ESV blockquotes use gendered pronouns for God (e.g., Genesis 6:5-6 "he had made man... it grieved him"). These are preserved as-is since they are direct citations. If we want to address these, options include switching translations or adding a framing note in the preface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)