### PR TITLE
Ch 8: replace penal substitutionary language with maturation framing

### DIFF
--- a/manuscript/ch08-moses-and-the-law.md
+++ b/manuscript/ch08-moses-and-the-law.md
@@ -76,7 +76,7 @@ Paul understood this:
 > Is the law then contrary to the promises of God? Certainly not! For if a law had been given that could give life, then righteousness would indeed be by the law. But the Scripture imprisoned everything under sin, so that the promise by faith in Jesus Christ might be given to those who believe.
 — [Galatians 3:21-22 ESV][10]
 
-The Law was never meant to save anyone. It was meant to show you why you need saving. It holds up a mirror and says: here is the standard, and here is how far you fall short. That gap — between what the Law demands and what you can deliver — is exactly where grace enters the story. But grace is a few chapters away. Humanity wasn't ready for it yet. You don't hand a child the keys and say "figure it out." You give them rules, let them fail, and wait until they're mature enough to understand why the rules mattered in the first place.
+The Law was never meant to save anyone. It was meant to reveal how much growing up humanity still had to do. It holds up a mirror: here is what faithfulness looks like, and here is where humanity actually stands. The distance between the two is not a courtroom verdict — it is a developmental reality. Closing it will require something the Law cannot provide. That something is grace, but grace is still a few chapters away. Humanity wasn't ready for it yet. You don't hand a child the keys and say "figure it out." You give them rules, let them fail, and wait until they're mature enough to understand why the rules mattered in the first place.
 
 ## The golden calf
 


### PR DESCRIPTION
## Summary
- Rewrites the paragraph following the Galatians 3:21-22 quote to remove penal substitutionary atonement language ("the standard," "how far you fall short," "the gap between what the Law demands and what you can deliver")
- Reframes through the book's maturation lens: the Law reveals developmental distance, not legal guilt. "Not a courtroom verdict — a developmental reality."
- Removes direct "you" address that presumed reader agreement with the theological premise; shifts to "humanity" as subject
- Preserves the grace forward-reference and parenting analogy unchanged

## Before
> The Law was never meant to save anyone. It was meant to show you why you need saving. It holds up a mirror and says: here is the standard, and here is how far you fall short. That gap — between what the Law demands and what you can deliver — is exactly where grace enters the story.

## After
> The Law was never meant to save anyone. It was meant to reveal how much growing up humanity still had to do. It holds up a mirror: here is what faithfulness looks like, and here is where humanity actually stands. The distance between the two is not a courtroom verdict — it is a developmental reality. Closing it will require something the Law cannot provide. That something is grace, but grace is still a few chapters away.

## Test plan
- [ ] Read the full paragraph in context (follows Galatians 3:21-22 quote, precedes golden calf section)
- [ ] Confirm it aligns with the maturation framework used in the rest of Ch 8 and the book

🤖 Generated with [Claude Code](https://claude.com/claude-code)