### PR TITLE
fix: grammar corrections in Ch 14, Ch 24, and Epilogue

### DIFF
--- a/manuscript/ch14-prayer.md
+++ b/manuscript/ch14-prayer.md
@@ -2,7 +2,7 @@
 
 Q: Does prayer work?
 
-A: Define "work." If you mean whether God grant requests, then no. If you mean whether prayer changes you, then yes. And that's the point.
+A: Define "work." If you mean whether God grants requests, then no. If you mean whether prayer changes you, then yes. And that's the point.
 
 ## Commentary
 

--- a/manuscript/ch24-the-decision.md
+++ b/manuscript/ch24-the-decision.md
@@ -50,7 +50,7 @@ Here is the real wager — the one the mission actually asks you to make.
 
 Will you give your life to something bigger than yourself, knowing it will cost you?
 
-Not: will you gain something by believing? Not: will your life be better, easier, more blessed? The mission does not promise you a comfortable life. Jesus was crucified. The disciples were martyred. The prophets were ignored, exiled, killed. Paul was beaten, shipwrecked, imprisoned. None of them lived an easy life. None of them were rewarded with comfort. The "better life" that mainstream Christianity sells — earthly blessing, eternal security in exchange for Sunday attendance — is a sweet poison. It is the opposite of what the mission demands. The mission does produce personal peace — the peace of knowing what you are for and giving yourself fully to it — but that peace accompanies the hardest work you will ever do, not a shortcut around it.
+Not: will you gain something by believing? Not: will your life be better, easier, more blessed? The mission does not promise you a comfortable life. Jesus was crucified. The disciples were martyred. The prophets were ignored, exiled, killed. Paul was beaten, shipwrecked, imprisoned. None of them lived an easy life. None of them were rewarded with comfort. The "better life" that mainstream Christianity sells — earthly blessing, eternal security in exchange for Sunday attendance — is a sweet poison. It is the opposite of what the mission demands. The mission does produce personal peace — the peace of knowing what you are for and giving yourself fully to it — but that peace accompanies the hardest work you will ever do. It is not a shortcut around it.
 
 The mission demands everything. And humanity needs you to carry it anyway.
 

--- a/manuscript/epilogue.md
+++ b/manuscript/epilogue.md
@@ -1,6 +1,6 @@
 # Epilogue: Now Go
 
-You have the mission. You have the victory conditions. You have the honest reckoning with everything the institution got wrong and the clarity to carry the mission without repeating it.
+You have the mission. You have the victory conditions. You have the honest reckoning with everything the institution got wrong and the clarity to carry the mission without repeating those mistakes.
 
 What you don't have is a community.
 


### PR DESCRIPTION
## Summary
Full grammar pass across all 30 manuscript files. Three issues found and fixed:

- **Ch 14 (Prayer):** "God grant" → "God grants" — subject-verb agreement
- **Ch 24 (The Decision):** Split sentence so "not a shortcut around it" reads as a clarification rather than a dangling comparison
- **Epilogue:** "without repeating it" → "without repeating those mistakes" — pronoun "it" ambiguously referred to "the mission" instead of institutional failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)