### PR TITLE
Add style guide (STYLE.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Ready for a shot of the truth? Straight, no chaser? Then let's go!
 [2]: https://www.esv.org/Matthew+22/
 [3]: http://themelios.thegospelcoalition.org/article/the-art-of-imperious-ignorance
 
+## Style guide
+
+See [STYLE.md](STYLE.md) for voice, tone, and editorial conventions.
+
 ## How to contribute
 
 Readers, ask your question or (respectfully) challenge existing content by creating an issue on [the Issues tab][4].

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,0 +1,38 @@
+# Style Guide
+
+These principles govern how we write. They emerged through editorial iteration across every chapter and are enforced in pull request reviews.
+
+For the theological foundations behind these choices, see [Core Tenets](reference/core-tenets.md).
+
+## Voice
+
+**Be direct.** State positions as truths, not opinions about opinions. "Tithing is a myth" not "this book argues that tithing is a myth." Avoid "this book" self-references entirely.
+
+**Be affirmative.** Tell the reader what to do, not what not to do. "You need to understand X so Y lands right" not "if you don't understand X, Y will go wrong." Strong statements are good — frame them as direction toward action.
+
+**Respect the reader.** Never talk down. "That sums up how God feels" not "if that doesn't tell you, nothing will." The reader chose to pick up this book. Trust their intelligence.
+
+**Build bridges.** State what we believe with conviction. Don't score points against those who disagree. "Here's what we think and why" is more inviting than "here's why they're wrong."
+
+**No double negatives.** Rephrase affirmatively. "That should unsettle you" not "if that doesn't unsettle you, you're not reading carefully enough."
+
+## Theological framing
+
+These are writing rules, not doctrinal statements. The reasoning lives in [Core Tenets](reference/core-tenets.md).
+
+**No substitutionary atonement.** The cross is proof that faithful mission-carrying is possible, not a cosmic transaction or debt payment.
+
+**No plan/blueprint metaphors for God.** God set creation in motion and it operates autonomously. Suffering isn't part of a design. The universe doesn't revolve around any individual's story.
+
+**No "obedience" language.** Obedience implies lack of thinking, which is the opposite of resilient faith. Frame faith as an active choice to move forward, not compliance.
+
+**No gender-specific pronouns for God.** Use "God" instead of he/him/his. ESV blockquotes are exempt — don't misquote Scripture.
+
+**Faith is internal, not performative.** The test of genuine faith is whether you've honestly faced doubt and still chosen to act — not whether others can see results. Visible results can be performed.
+
+## Conventions
+
+- Scripture references use ESV
+- Each chapter ends with 2-3 self-examination questions that challenge the reader
+- Chapter navigation links at the bottom of every page
+- Straight-no-chaser energy throughout — no hedging, no theological jargon


### PR DESCRIPTION
## Summary
- New `STYLE.md` codifying the voice and editorial principles that emerged through 90+ PRs of refinement
- Three sections: Voice (affirmative framing, respect the reader, build bridges, no double negatives), Theological framing (no PSA, no plan metaphors, no obedience language, no gendered God pronouns), Conventions (ESV, self-examination questions, navigation)
- README updated with a one-line pointer to the style guide

## Test plan
- [x] Verify STYLE.md renders correctly on GitHub
- [x] Verify README link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)