### PR TITLE
Add part pages to reading navigation

### DIFF
--- a/manuscript/ch01-god.md
+++ b/manuscript/ch01-god.md
@@ -88,4 +88,4 @@ That last question matters more than you think. Because the mission isn't abstra
 
 ---
 
-[← Preface](preface.html) · [Table of Contents](../) · [Hour 2: The Bible →](ch02-the-bible.html)
+[← Part I: The Foundation](part1.html) · [Table of Contents](../) · [Hour 2: The Bible →](ch02-the-bible.html)

--- a/manuscript/ch06-holy-spirit.md
+++ b/manuscript/ch06-holy-spirit.md
@@ -136,4 +136,4 @@ Part II will trace the story — from creation to the early church — so you ca
 
 ---
 
-[← Hour 5: Faith](ch05-faith.html) · [Table of Contents](../) · [Hour 7: Creation to Abraham →](ch07-creation-to-abraham.html)
+[← Hour 5: Faith](ch05-faith.html) · [Table of Contents](../) · [Part II: The Story →](part2.html)

--- a/manuscript/ch07-creation-to-abraham.md
+++ b/manuscript/ch07-creation-to-abraham.md
@@ -165,4 +165,4 @@ The mission started in a garden. It nearly ended in a flood. It survived in a co
 
 ---
 
-[← Hour 6: The Holy Spirit](ch06-holy-spirit.html) · [Table of Contents](../) · [Hour 8: Moses and the Law →](ch08-moses-and-the-law.html)
+[← Part II: The Story](part2.html) · [Table of Contents](../) · [Hour 8: Moses and the Law →](ch08-moses-and-the-law.html)

--- a/manuscript/ch12-the-early-church.md
+++ b/manuscript/ch12-the-early-church.md
@@ -129,4 +129,4 @@ The story has been told. The question now is whether you will live it.
 
 ---
 
-[← Hour 11: Jesus — The Death and Resurrection](ch11-jesus-death-resurrection.html) · [Table of Contents](../) · [Hour 13: Love God, Love Your Neighbor →](ch13-love-god-love-neighbor.html)
+[← Hour 11: Jesus — The Death and Resurrection](ch11-jesus-death-resurrection.html) · [Table of Contents](../) · [Part III: The Life →](part3.html)

--- a/manuscript/ch13-love-god-love-neighbor.md
+++ b/manuscript/ch13-love-god-love-neighbor.md
@@ -117,4 +117,4 @@ The story has been told. This is where the living starts.
 
 ---
 
-[← Hour 12: The Early Church](ch12-the-early-church.html) · [Table of Contents](../) · [Hour 14: Prayer →](ch14-prayer.html)
+[← Part III: The Life](part3.html) · [Table of Contents](../) · [Hour 14: Prayer →](ch14-prayer.html)

--- a/manuscript/ch18-forgiveness.md
+++ b/manuscript/ch18-forgiveness.md
@@ -116,4 +116,4 @@ The point is not perfection. The point is direction. Are you moving toward relea
 
 ---
 
-[← Hour 17: Suffering](ch17-suffering.html) · [Table of Contents](../) · [Hour 19: Fake Faith →](ch19-fake-faith.html)
+[← Hour 17: Suffering](ch17-suffering.html) · [Table of Contents](../) · [Part IV: The Decision →](part4.html)

--- a/manuscript/ch19-fake-faith.md
+++ b/manuscript/ch19-fake-faith.md
@@ -113,4 +113,4 @@ Real faith is what remains when you've stripped away the performance, the incent
 
 ---
 
-[← Hour 18: Forgiveness](ch18-forgiveness.html) · [Table of Contents](../) · [Hour 20: Hard Questions →](ch20-hard-questions.html)
+[← Part IV: The Decision](part4.html) · [Table of Contents](../) · [Hour 20: Hard Questions →](ch20-hard-questions.html)

--- a/manuscript/part1.md
+++ b/manuscript/part1.md
@@ -1,5 +1,12 @@
 # Part I — The Foundation
 
+- Hour 1: [God](ch01-god.html)
+- Hour 2: [The Bible](ch02-the-bible.html)
+- Hour 3: [Sin](ch03-sin.html)
+- Hour 4: [Salvation](ch04-salvation.html)
+- Hour 5: [Faith](ch05-faith.html)
+- Hour 6: [The Holy Spirit](ch06-holy-spirit.html)
+
 ---
 
 [← Preface](preface.html) · [Table of Contents](../) · [Hour 1: God →](ch01-god.html)

--- a/manuscript/part1.md
+++ b/manuscript/part1.md
@@ -1,1 +1,5 @@
 # Part I — The Foundation
+
+---
+
+[← Preface](preface.html) · [Table of Contents](../) · [Hour 1: God →](ch01-god.html)

--- a/manuscript/part2.md
+++ b/manuscript/part2.md
@@ -1,5 +1,12 @@
 # Part II — The Story
 
+- Hour 7: [Creation to Abraham](ch07-creation-to-abraham.html)
+- Hour 8: [Moses and the Law](ch08-moses-and-the-law.html)
+- Hour 9: [The Prophets](ch09-the-prophets.html)
+- Hour 10: [Jesus: The Life](ch10-jesus-the-life.html)
+- Hour 11: [Jesus: The Death and Resurrection](ch11-jesus-death-resurrection.html)
+- Hour 12: [The Early Church](ch12-the-early-church.html)
+
 ---
 
 [← Hour 6: The Holy Spirit](ch06-holy-spirit.html) · [Table of Contents](../) · [Hour 7: Creation to Abraham →](ch07-creation-to-abraham.html)

--- a/manuscript/part2.md
+++ b/manuscript/part2.md
@@ -1,1 +1,5 @@
 # Part II — The Story
+
+---
+
+[← Hour 6: The Holy Spirit](ch06-holy-spirit.html) · [Table of Contents](../) · [Hour 7: Creation to Abraham →](ch07-creation-to-abraham.html)

--- a/manuscript/part3.md
+++ b/manuscript/part3.md
@@ -1,1 +1,5 @@
 # Part III — The Life
+
+---
+
+[← Hour 12: The Early Church](ch12-the-early-church.html) · [Table of Contents](../) · [Hour 13: Love God, Love Your Neighbor →](ch13-love-god-love-neighbor.html)

--- a/manuscript/part3.md
+++ b/manuscript/part3.md
@@ -1,5 +1,12 @@
 # Part III — The Life
 
+- Hour 13: [Love God, Love Your Neighbor](ch13-love-god-love-neighbor.html)
+- Hour 14: [Prayer](ch14-prayer.html)
+- Hour 15: [Community](ch15-community.html)
+- Hour 16: [Giving](ch16-giving.html)
+- Hour 17: [Suffering](ch17-suffering.html)
+- Hour 18: [Forgiveness](ch18-forgiveness.html)
+
 ---
 
 [← Hour 12: The Early Church](ch12-the-early-church.html) · [Table of Contents](../) · [Hour 13: Love God, Love Your Neighbor →](ch13-love-god-love-neighbor.html)

--- a/manuscript/part4.md
+++ b/manuscript/part4.md
@@ -1,5 +1,12 @@
 # Part IV — The Decision
 
+- Hour 19: [Fake Faith](ch19-fake-faith.html)
+- Hour 20: [Hard Questions](ch20-hard-questions.html)
+- Hour 21: [Christianity and the World](ch21-christianity-and-the-world.html)
+- Hour 22: [Reading the Bible](ch22-reading-the-bible.html)
+- Hour 23: [Death and What Comes After](ch23-death-and-afterlife.html)
+- Hour 24: [The Decision](ch24-the-decision.html)
+
 ---
 
 [← Hour 18: Forgiveness](ch18-forgiveness.html) · [Table of Contents](../) · [Hour 19: Fake Faith →](ch19-fake-faith.html)

--- a/manuscript/part4.md
+++ b/manuscript/part4.md
@@ -1,1 +1,5 @@
 # Part IV — The Decision
+
+---
+
+[← Hour 18: Forgiveness](ch18-forgiveness.html) · [Table of Contents](../) · [Hour 19: Fake Faith →](ch19-fake-faith.html)

--- a/manuscript/preface.md
+++ b/manuscript/preface.md
@@ -16,4 +16,4 @@ Like Neo meeting Morpheus for the first time in _The Matrix_, you can choose now
 
 ---
 
-[Table of Contents](../) · [Hour 1: God →](ch01-god.html)
+[Table of Contents](../) · [Part I: The Foundation →](part1.html)


### PR DESCRIPTION
## Summary
- Part transition pages (Part I–IV) now appear in the sequential reading flow
- Boundary chapters point to/from the part page instead of skipping it
- Reading path: Preface → **Part I** → Ch 1 ... Ch 6 → **Part II** → Ch 7 ... Ch 12 → **Part III** → Ch 13 ... Ch 18 → **Part IV** → Ch 19 ... Ch 24 → Epilogue
- 12 files changed: 4 part pages + 8 boundary chapters (preface, ch01, ch06, ch07, ch12, ch13, ch18, ch19)

## Test plan
- [x] Verify navigation links render correctly on GitHub Pages
- [x] Verify forward/backward reading flow is unbroken through all 30 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)