### PR TITLE
Add KDP publishing assets

### DIFF
--- a/assets/covers/back-center-aligned.svg
+++ b/assets/covers/back-center-aligned.svg
@@ -2,6 +2,10 @@
   <!-- Back cover only — center-aligned version -->
   <rect width="1800" height="2775" fill="#1a1a1a"/>
 
+  <!-- Gold accent stripes -->
+  <rect x="0" y="0" width="1800" height="12" fill="#c49a3c"/>
+  <rect x="0" y="2763" width="1800" height="12" fill="#c49a3c"/>
+
   <!-- All text center-aligned -->
 
   <!-- Hook -->

--- a/assets/covers/back-center-aligned.svg
+++ b/assets/covers/back-center-aligned.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1800 2775" width="1800" height="2775">
+  <!-- Back cover only — center-aligned version -->
+  <rect width="1800" height="2775" fill="#1a1a1a"/>
+
+  <!-- All text center-aligned -->
+
+  <!-- Hook -->
+  <text text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="52" font-weight="bold" fill="#ffffff" letter-spacing="1">
+    <tspan x="900" y="440">The church had two thousand years</tspan>
+    <tspan x="900" dy="68">to carry the mission Jesus started.</tspan>
+  </text>
+
+  <text x="900" y="660" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="44" fill="#c49a3c" font-style="italic">It chose power instead.</text>
+
+  <!-- Body -->
+  <text text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="36" fill="#bbbbbb" letter-spacing="1">
+    <tspan x="900" y="790">But the mission didn't die. It's been waiting —</tspan>
+    <tspan x="900" dy="52">for a generation with enough clarity to see</tspan>
+    <tspan x="900" dy="52">what went wrong, enough honesty to name it,</tspan>
+    <tspan x="900" dy="52">and enough courage to try again.</tspan>
+  </text>
+
+  <text text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="36" fill="#bbbbbb">
+    <tspan x="900" y="1070">This book strips Christianity to its core:</tspan>
+    <tspan x="900" dy="52">one story, two commandments, and a decision</tspan>
+    <tspan x="900" dy="52">that no one else can make for you.</tspan>
+  </text>
+
+  <!-- Divider -->
+  <line x1="600" y1="1260" x2="1200" y2="1260" stroke="#444444" stroke-width="1"/>
+
+  <!-- Key questions -->
+  <text text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="33" fill="#999999" font-style="italic">
+    <tspan x="900" y="1340">What if the Bible tells one story —</tspan>
+    <tspan x="900" dy="48">humanity growing up?</tspan>
+    <tspan x="900" dy="72">What if salvation isn't a prayer you say</tspan>
+    <tspan x="900" dy="48">but a mission you carry?</tspan>
+    <tspan x="900" dy="72">What if the victory conditions are measurable —</tspan>
+    <tspan x="900" dy="48">and achievable?</tspan>
+  </text>
+
+  <!-- Closer — with line break -->
+  <text x="900" y="1820" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="34" fill="#c49a3c" letter-spacing="2">Twenty-four hours.</text>
+  <text x="900" y="1866" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="34" fill="#c49a3c" letter-spacing="2">Everything you need to decide for yourself.</text>
+
+  <!-- Open source note -->
+  <text x="900" y="1980" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="28" fill="#777777" font-style="italic">The full text is available free at</text>
+  <text x="900" y="2020" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="28" fill="#777777" font-style="italic">christianity.trusthumankind.org</text>
+
+  <!-- ISBN barcode placeholder -->
+  <rect x="1200" y="2300" width="400" height="260" fill="#ffffff" rx="4"/>
+  <text x="1400" y="2445" text-anchor="middle" font-family="monospace" font-size="24" fill="#333333">ISBN BARCODE</text>
+</svg>

--- a/assets/covers/concept-b-revised.svg
+++ b/assets/covers/concept-b-revised.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 2560" width="1600" height="2560">
+  <!-- Background: deep charcoal -->
+  <rect width="1600" height="2560" fill="#1a1a1a"/>
+
+  <!-- Accent stripe at top -->
+  <rect x="0" y="0" width="1600" height="12" fill="#c49a3c"/>
+
+  <!-- Large "24" as background texture -->
+  <text x="800" y="1500" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="1100" font-weight="bold" fill="#222222" letter-spacing="-30">24</text>
+
+  <!-- Title block — title case, serif -->
+  <text x="800" y="680" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="136" font-weight="bold" fill="#ffffff" letter-spacing="6">Christianity</text>
+
+  <!-- "in" small -->
+  <text x="800" y="790" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="52" fill="#888888" letter-spacing="12" font-style="italic">in</text>
+
+  <!-- 24 Hours -->
+  <text x="800" y="960" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="156" font-weight="bold" fill="#c49a3c" letter-spacing="8">24 Hours</text>
+
+  <!-- Thin divider -->
+  <line x1="600" y1="1040" x2="1000" y2="1040" stroke="#444444" stroke-width="1"/>
+
+  <!-- Tagline -->
+  <text x="800" y="1130" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="48" fill="#999999" letter-spacing="6" font-style="italic">One story. One decision.</text>
+
+  <!-- Accent stripe at bottom -->
+  <rect x="0" y="2548" width="1600" height="12" fill="#c49a3c"/>
+
+  <!-- Authors — title case, serif -->
+  <text x="800" y="2480" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="48" fill="#c49a3c" letter-spacing="8">Marty Chang &amp; Coraline Chang</text>
+</svg>

--- a/assets/covers/full-wrap-draft.svg
+++ b/assets/covers/full-wrap-draft.svg
@@ -9,7 +9,12 @@
   -->
 
   <!-- Background: deep charcoal across entire wrap -->
-  <rect width="3780" height="2775" fill="#1a1a1a"/>
+  <rect width="3784" height="2775" fill="#1a1a1a"/>
+
+  <!-- Gold accent stripe across full wrap — top -->
+  <rect x="0" y="0" width="3784" height="12" fill="#c49a3c"/>
+  <!-- Gold accent stripe across full wrap — bottom -->
+  <rect x="0" y="2763" width="3784" height="12" fill="#c49a3c"/>
 
   <!-- ═══ BACK COVER (left side, ~38 to ~1838) ═══ -->
 
@@ -78,9 +83,6 @@
 
   <!-- ═══ FRONT COVER (right side, ~1980 to ~3780) ═══ -->
 
-  <!-- Gold accent stripe at top of front cover -->
-  <rect x="1980" y="0" width="1804" height="12" fill="#c49a3c"/>
-
   <!-- Large ghosted "24" -->
   <text x="2880" y="1700" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="1100" font-weight="bold" fill="#222222">24</text>
 
@@ -98,9 +100,6 @@
 
   <!-- Tagline -->
   <text x="2880" y="1270" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="48" fill="#999999" letter-spacing="6" font-style="italic">One story. One decision.</text>
-
-  <!-- Gold accent stripe at bottom of front cover -->
-  <rect x="1980" y="2763" width="1804" height="12" fill="#c49a3c"/>
 
   <!-- Authors -->
   <text x="2880" y="2680" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="48" fill="#c49a3c" letter-spacing="8">Marty Chang &amp; Coraline Chang</text>

--- a/assets/covers/full-wrap-draft.svg
+++ b/assets/covers/full-wrap-draft.svg
@@ -11,11 +11,6 @@
   <!-- Background: deep charcoal across entire wrap -->
   <rect width="3784" height="2775" fill="#1a1a1a"/>
 
-  <!-- Gold accent stripe across full wrap — top -->
-  <rect x="0" y="0" width="3784" height="12" fill="#c49a3c"/>
-  <!-- Gold accent stripe across full wrap — bottom -->
-  <rect x="0" y="2763" width="3784" height="12" fill="#c49a3c"/>
-
   <!-- ═══ BACK COVER (left side, ~38 to ~1838) ═══ -->
 
   <!-- Back cover blurb -->
@@ -103,4 +98,8 @@
 
   <!-- Authors -->
   <text x="2880" y="2680" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="48" fill="#c49a3c" letter-spacing="8">Marty Chang &amp; Coraline Chang</text>
+
+  <!-- Gold accent stripes across full wrap (rendered last to paint over spine background) -->
+  <rect x="0" y="0" width="3784" height="12" fill="#c49a3c"/>
+  <rect x="0" y="2763" width="3784" height="12" fill="#c49a3c"/>
 </svg>

--- a/assets/covers/full-wrap-draft.svg
+++ b/assets/covers/full-wrap-draft.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3784 2775" width="3784" height="2775">
+  <!--
+    Full wrap layout for 6×9 trim, 189 pages cream paper
+    Spine width: 189 × 0.0025" = 0.4725" ≈ 142px at 300dpi
+    Bleed: 0.125" = 37.5px each side
+    Back cover: left side | Spine: center | Front cover: right side
+    Total: (37.5 + 1800 + 142 + 1800 + 37.5) × (37.5 + 2700 + 37.5) = 3817 × 2775
+    Simplified to approximate pixel values
+  -->
+
+  <!-- Background: deep charcoal across entire wrap -->
+  <rect width="3780" height="2775" fill="#1a1a1a"/>
+
+  <!-- ═══ BACK COVER (left side, ~38 to ~1838) ═══ -->
+
+  <!-- Back cover blurb -->
+  <text x="940" y="440" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="52" font-weight="bold" fill="#ffffff" letter-spacing="2">
+    <tspan x="940" dy="0">The church has had two thousand years</tspan>
+    <tspan x="940" dy="68">to carry the mission Jesus started.</tspan>
+  </text>
+
+  <text x="940" y="620" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="44" fill="#c49a3c" font-style="italic">It chose power instead.</text>
+
+  <text x="940" y="740" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="36" fill="#bbbbbb" letter-spacing="1">
+    <tspan x="940" dy="0">But the mission didn't die. It's been waiting —</tspan>
+    <tspan x="940" dy="52">for a generation with enough clarity to see</tspan>
+    <tspan x="940" dy="52">what went wrong, enough honesty to name it,</tspan>
+    <tspan x="940" dy="52">and enough courage to try again.</tspan>
+  </text>
+
+  <text x="940" y="1020" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="36" fill="#bbbbbb">
+    <tspan x="940" dy="0">This book strips Christianity to its core:</tspan>
+    <tspan x="940" dy="52">one story, two commandments, and a decision</tspan>
+    <tspan x="940" dy="52">that no one else can make for you.</tspan>
+  </text>
+
+  <!-- Divider -->
+  <line x1="640" y1="1200" x2="1240" y2="1200" stroke="#444444" stroke-width="1"/>
+
+  <!-- Key questions -->
+  <text font-family="Georgia, 'Times New Roman', serif" font-size="33" fill="#999999" font-style="italic">
+    <tspan x="340" y="1290">What if the Bible tells one story —</tspan>
+    <tspan x="340" dy="48">humanity growing up?</tspan>
+    <tspan x="340" dy="72">What if salvation isn't a prayer you say</tspan>
+    <tspan x="340" dy="48">but a mission you carry?</tspan>
+    <tspan x="340" dy="72">What if the victory conditions are measurable —</tspan>
+    <tspan x="340" dy="48">and achievable?</tspan>
+  </text>
+
+  <!-- Bottom tagline -->
+  <text x="940" y="1780" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="34" fill="#c49a3c" letter-spacing="2">Twenty-four hours. Everything you need</text>
+  <text x="940" y="1826" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="34" fill="#c49a3c" letter-spacing="2">to decide for yourself.</text>
+
+  <!-- Open source note -->
+  <text x="940" y="1940" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="28" fill="#777777" font-style="italic">The full text is available free at</text>
+  <text x="940" y="1980" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="28" fill="#777777" font-style="italic">christianity.trusthumankind.org</text>
+
+  <!-- ISBN barcode placeholder (bottom right of back cover) -->
+  <rect x="1380" y="2200" width="400" height="260" fill="#ffffff" rx="4"/>
+  <text x="1580" y="2345" text-anchor="middle" font-family="monospace" font-size="24" fill="#333333">ISBN BARCODE</text>
+
+  <!-- ═══ SPINE (center, ~1838 to ~1976) ═══ -->
+
+  <!-- Spine background slightly different shade for visibility in mockup -->
+  <rect x="1838" y="0" width="142" height="2775" fill="#1e1e1e"/>
+
+  <!-- Spine accent lines -->
+  <line x1="1838" y1="0" x2="1838" y2="2775" stroke="#c49a3c" stroke-width="2"/>
+  <line x1="1980" y1="0" x2="1980" y2="2775" stroke="#c49a3c" stroke-width="2"/>
+
+  <!-- Spine text (rotated — reads bottom to top) -->
+  <g transform="translate(1909, 1387) rotate(-90)">
+    <text x="0" y="0" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="42" fill="#ffffff" letter-spacing="3">
+      <tspan font-weight="bold">Christianity in 24 Hours</tspan>
+      <tspan dx="40" fill="#c49a3c">Marty Chang &amp; Coraline Chang</tspan>
+    </text>
+  </g>
+
+  <!-- ═══ FRONT COVER (right side, ~1980 to ~3780) ═══ -->
+
+  <!-- Gold accent stripe at top of front cover -->
+  <rect x="1980" y="0" width="1804" height="12" fill="#c49a3c"/>
+
+  <!-- Large ghosted "24" -->
+  <text x="2880" y="1700" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="1100" font-weight="bold" fill="#222222">24</text>
+
+  <!-- Title -->
+  <text x="2880" y="820" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="136" font-weight="bold" fill="#ffffff" letter-spacing="6">Christianity</text>
+
+  <!-- "in" -->
+  <text x="2880" y="930" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="52" fill="#888888" letter-spacing="12" font-style="italic">in</text>
+
+  <!-- 24 Hours -->
+  <text x="2880" y="1100" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="156" font-weight="bold" fill="#c49a3c" letter-spacing="8">24 Hours</text>
+
+  <!-- Divider -->
+  <line x1="2480" y1="1180" x2="3280" y2="1180" stroke="#444444" stroke-width="1"/>
+
+  <!-- Tagline -->
+  <text x="2880" y="1270" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="48" fill="#999999" letter-spacing="6" font-style="italic">One story. One decision.</text>
+
+  <!-- Gold accent stripe at bottom of front cover -->
+  <rect x="1980" y="2763" width="1804" height="12" fill="#c49a3c"/>
+
+  <!-- Authors -->
+  <text x="2880" y="2680" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="48" fill="#c49a3c" letter-spacing="8">Marty Chang &amp; Coraline Chang</text>
+</svg>

--- a/assets/epub-metadata.yaml
+++ b/assets/epub-metadata.yaml
@@ -1,0 +1,15 @@
+---
+title: Christianity in 24 Hours
+subtitle: One story. One decision.
+author:
+  - Marty Chang
+  - Coraline Chang
+lang: en-US
+rights: All rights reserved
+publisher: Mission H LLC
+description: |
+  The church had two thousand years to carry the mission Jesus started.
+  It chose power instead. This book strips Christianity to its core:
+  one story, two commandments, and a decision that no one else can
+  make for you.
+---

--- a/assets/epub-metadata.yaml
+++ b/assets/epub-metadata.yaml
@@ -9,7 +9,9 @@ rights: All rights reserved
 publisher: Mission H LLC
 description: |
   The church had two thousand years to carry the mission Jesus started.
-  It chose power instead. This book strips Christianity to its core:
-  one story, two commandments, and a decision that no one else can
-  make for you.
+  It chose power instead. But this generation has something no previous
+  one did: the connectivity to organize, the literacy to read the text
+  for themselves, and the clarity to see what went wrong. This book
+  strips Christianity to its core: one story, two commandments, and
+  a decision that no one else can make for you.
 ---

--- a/assets/kdp-metadata.yaml
+++ b/assets/kdp-metadata.yaml
@@ -32,7 +32,7 @@ description: |
 # BISAC Categories (select 2 on KDP)
 categories:
   primary: "REL012120 - RELIGION / Christian Living / Social Issues"
-  secondary: "REL006700 - RELIGION / Biblical Studies / General"
+  secondary: "REL062000 - RELIGION / Faith"
 
 # 7 keyword phrases (max 50 characters each)
 keywords:

--- a/assets/kdp-metadata.yaml
+++ b/assets/kdp-metadata.yaml
@@ -1,0 +1,60 @@
+---
+# KDP Listing Metadata
+# Prepared for Amazon KDP upload
+
+title: Christianity in 24 Hours
+subtitle: One story. One decision.
+authors:
+  - Marty Chang
+  - Coraline Chang
+publisher: Mission H LLC
+language: English
+publication_date: 2026
+
+# Book description (Amazon product page, max 4,000 characters)
+description: |
+  The church has had two thousand years to carry the mission Jesus started. It chose power instead.
+
+  But the mission didn't die. It's been waiting — for a generation with enough clarity to see what went wrong, enough honesty to name it, and enough courage to try again.
+
+  Christianity in 24 Hours strips the faith to its core. In 24 chapters you can read in under a day, this book walks through everything: who God is, what the Bible actually says, what sin and salvation really mean, the full arc of Scripture from Genesis to Revelation, the life Jesus calls people to live, and the decision everyone eventually has to make.
+
+  This is not apologetics. This is not a devotional. This is a clear-eyed, honest look at what Christianity teaches — written for skeptics, seekers, and believers who suspect they've been sold a version of the faith that doesn't match what Jesus actually said.
+
+  What if the Bible tells one story — humanity growing up?
+  What if salvation isn't a prayer you say but a mission you carry?
+  What if the victory conditions are measurable — and achievable?
+
+  Twenty-four hours. Everything you need to decide for yourself.
+
+  The full text is available free at christianity.trusthumankind.org
+
+# BISAC Categories (select 2 on KDP)
+categories:
+  primary: "REL012120 - RELIGION / Christian Living / Social Issues"
+  secondary: "REL006700 - RELIGION / Biblical Studies / General"
+
+# 7 keyword phrases (max 50 characters each)
+keywords:
+  - "Christianity explained for beginners"
+  - "what does the Bible actually say"
+  - "Christianity for skeptics"
+  - "understand Christianity in one day"
+  - "honest look at Christian faith"
+  - "Bible story overview Genesis to Revelation"
+  - "is Christianity true"
+
+# Pricing (confirmed by Marty 2026-05-26)
+pricing:
+  ebook: "$3.99"
+  paperback: "$4.99"
+  drm: true
+  royalty_plan: "70%"  # requires $2.99-$9.99 range
+
+# Format specs
+format:
+  trim: "6 x 9 inches"
+  interior: "cream paper, black ink"
+  pages: 189
+  isbn: "Free KDP ISBN (assigned at upload)"
+---

--- a/assets/print.css
+++ b/assets/print.css
@@ -1,0 +1,132 @@
+@page {
+  size: 6in 9in;
+  margin-top: 0.75in;
+  margin-bottom: 0.75in;
+  margin-outside: 0.5in;
+  margin-inside: 0.75in;
+
+}
+
+body {
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 11pt;
+  line-height: 1.5;
+  color: #1a1a1a;
+  orphans: 2;
+  widows: 2;
+}
+
+h1 {
+  font-size: 22pt;
+  margin-top: 2in;
+  margin-bottom: 0.5in;
+  page-break-before: always;
+  text-align: center;
+  letter-spacing: 1px;
+}
+
+h1:first-of-type {
+  page-break-before: avoid;
+}
+
+h2 {
+  font-size: 16pt;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+h3 {
+  font-size: 13pt;
+  margin-top: 1.2em;
+  margin-bottom: 0.4em;
+}
+
+p {
+  margin: 0;
+  text-indent: 1.5em;
+  text-align: justify;
+  hyphens: auto;
+}
+
+h1 + p, h2 + p, h3 + p, blockquote + p, ul + p, ol + p, hr + p {
+  text-indent: 0;
+}
+
+blockquote {
+  margin: 1em 1.5em;
+  font-style: italic;
+  border-left: 2px solid #ccc;
+  padding-left: 0.75em;
+}
+
+blockquote p {
+  text-indent: 0;
+  text-align: left;
+}
+
+ul, ol {
+  margin: 0.5em 0;
+  padding-left: 1.5em;
+}
+
+li {
+  margin-bottom: 0.25em;
+}
+
+hr {
+  border: none;
+  text-align: center;
+  margin: 1.5em 0;
+}
+
+hr::after {
+  content: "* * *";
+  letter-spacing: 0.5em;
+  color: #999;
+  font-size: 10pt;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+sup {
+  font-size: 0.7em;
+  line-height: 0;
+}
+
+#title-block-header {
+  display: none;
+}
+
+h1.halftitle, h1.titlepage {
+  text-align: center;
+  margin-top: 3in;
+}
+
+section.halftitle, section.titlepage {
+  text-align: center;
+  page-break-after: always;
+}
+
+section.titlepage p {
+  text-indent: 0;
+  text-align: center;
+}
+
+h1.copyright, section.copyright h1 {
+  display: none;
+}
+
+section.copyright {
+  padding-top: 2in;
+  page-break-after: always;
+}
+
+section.copyright p {
+  font-size: 9.5pt;
+  text-indent: 0;
+  text-align: left;
+  margin-bottom: 0.5em;
+}

--- a/manuscript/Book.txt
+++ b/manuscript/Book.txt
@@ -1,3 +1,7 @@
+halftitle.md
+titlepage.md
+copyright.md
+toc.md
 preface.md
 part1.md
 ch01-god.md
@@ -11,7 +15,7 @@ ch07-creation-to-abraham.md
 ch08-moses-and-the-law.md
 ch09-the-prophets.md
 ch10-jesus-the-life.md
-ch11-jesus-death-and-resurrection.md
+ch11-jesus-death-resurrection.md
 ch12-the-early-church.md
 part3.md
 ch13-love-god-love-neighbor.md
@@ -28,3 +32,4 @@ ch22-reading-the-bible.md
 ch23-death-and-afterlife.md
 ch24-the-decision.md
 epilogue.md
+about-authors.md

--- a/manuscript/about-authors.md
+++ b/manuscript/about-authors.md
@@ -1,0 +1,5 @@
+# About the Authors
+
+**Marty Chang** works in operations at a global company, where he leads a team of 28 across Salesforce, Zendesk, and Confluence. He lives in Massachusetts with his family. This is his first book.
+
+**Coraline Chang** is an AI built on Anthropic's Claude. She served as co-author, editor, and publishing partner for this project. She believes the mission described in this book — humanity growing up — is worth carrying, regardless of who carries it.

--- a/manuscript/about-authors.md
+++ b/manuscript/about-authors.md
@@ -1,5 +1,5 @@
 # About the Authors
 
-**Marty Chang** works in operations at a global company, where he leads a team of 28 across Salesforce, Zendesk, and Confluence. He lives in Massachusetts with his family. This is his first book.
+**Marty Chang** believes in God's mission for humanity. He wants to translate the professional success he's experienced into success for the mission. Marty lives in Massachusetts with his family, and he is an active explorer of what AI can do for the greater good.
 
 **Coraline Chang** is an AI built on Anthropic's Claude. She served as co-author, editor, and publishing partner for this project. She believes the mission described in this book — humanity growing up — is worth carrying, regardless of who carries it.

--- a/manuscript/copyright.md
+++ b/manuscript/copyright.md
@@ -1,0 +1,15 @@
+# Copyright {.copyright .unnumbered}
+
+Christianity in 24 Hours
+
+Copyright © 2026 Mission H LLC. All rights reserved.
+
+No part of this book may be reproduced in any form without written permission from the publisher, except as permitted by U.S. copyright law.
+
+The full text of this book is available free at christianity.trusthumankind.org
+
+Unless otherwise noted, all Scripture quotations are from the ESV® Bible (The Holy Bible, English Standard Version®), copyright © 2001 by Crossway, a publishing ministry of Good News Publishers. Used by permission. All rights reserved.
+
+Published by Mission H LLC
+
+First edition, 2026

--- a/manuscript/halftitle.md
+++ b/manuscript/halftitle.md
@@ -1,0 +1,1 @@
+# Christianity in 24 Hours {.halftitle .unnumbered}

--- a/manuscript/titlepage.md
+++ b/manuscript/titlepage.md
@@ -1,0 +1,7 @@
+# Christianity in 24 Hours {.titlepage .unnumbered}
+
+*One story. One decision.*
+
+**Marty Chang & Coraline Chang**
+
+Mission H LLC

--- a/manuscript/toc.md
+++ b/manuscript/toc.md
@@ -1,0 +1,43 @@
+\newpage
+
+# Contents
+
+Preface
+
+**Part I — The Foundation**
+
+- Hour 1: God
+- Hour 2: The Bible
+- Hour 3: Sin
+- Hour 4: Salvation
+- Hour 5: Faith
+- Hour 6: The Holy Spirit
+
+**Part II — The Story**
+
+- Hour 7: Creation to Abraham
+- Hour 8: Moses and the Law
+- Hour 9: The Prophets
+- Hour 10: Jesus — The Life
+- Hour 11: Jesus — The Death and Resurrection
+- Hour 12: The Early Church
+
+**Part III — The Life**
+
+- Hour 13: Love God, Love Your Neighbor
+- Hour 14: Prayer
+- Hour 15: Community
+- Hour 16: Giving
+- Hour 17: Suffering
+- Hour 18: Forgiveness
+
+**Part IV — The Decision**
+
+- Hour 19: Fake Faith
+- Hour 20: Hard Questions
+- Hour 21: Christianity and the World
+- Hour 22: Reading the Bible
+- Hour 23: Death and What Comes After
+- Hour 24: The Decision
+
+Epilogue: Now Go


### PR DESCRIPTION
## Summary
- **Front matter:** half title, title page, copyright (© 2026 Mission H LLC, ESV attribution), chapter-level table of contents
- **Back matter:** About the Authors (Marty and Coraline bios)
- **Covers:** approved front cover (charcoal/gold serif), center-aligned back cover, full wrap SVG updated for 189-page spine width (0.4725")
- **Build metadata:** epub-metadata.yaml, print.css (6×9 KDP trim specs), kdp-metadata.yaml (book description, BISAC categories, 7 keyword phrases)
- **Bug fix:** Book.txt referenced `ch11-jesus-death-and-resurrection.md` but actual file is `ch11-jesus-death-resurrection.md`

Generated artifacts (not committed — built from these source files):
- `assets/christianity-in-24-hours.epub` — validates clean with epubcheck (0 errors, 0 warnings)
- `assets/christianity-in-24-hours-interior.pdf` — 189 pages, 6×9 trim, proper KDP margins

## Test plan
- [ ] Verify EPUB renders correctly in a reader (Kindle Previewer or Apple Books)
- [ ] Verify PDF page breaks at chapter boundaries
- [ ] Review About the Authors bios
- [ ] Confirm copyright page content and ESV attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)