### PR TITLE
EPUB build docs and KDP-ready manuscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,87 @@ Ready for a shot of the truth? Straight, no chaser? Then let's go!
 
 See [STYLE.md](STYLE.md) for voice, tone, and editorial conventions.
 
+## Building the EPUB
+
+### Prerequisites
+
+```bash
+brew install pandoc epubcheck librsvg
+```
+
+### Build steps
+
+1. **Prepare manuscript files.** The source Markdown files contain website navigation links and `.html` cross-references that must be stripped for EPUB:
+
+```bash
+mkdir -p /tmp/epub-build
+python3 -c "
+import re
+for line in open('manuscript/Book.txt'):
+    f = line.strip()
+    if not f: continue
+    content = open(f'manuscript/{f}').read()
+    content = re.sub(r'\[([^\]]*)\]\([^)]*\.html\)', r'\1', content)
+    content = re.sub(r'\[Table of Contents\]\(\.\./\)', 'Table of Contents', content)
+    lines = [l for l in content.split('\n')
+             if '· Table of Contents' not in l
+             and not l.startswith('Table of Contents ·')]
+    while lines and lines[-1].strip() in ('', '---'): lines.pop()
+    lines.append('')
+    open(f'/tmp/epub-build/{f}', 'w').write('\n'.join(lines))
+"
+```
+
+2. **Build the EPUB** with pandoc (no cover — KDP requires the cover as a separate upload):
+
+```bash
+pandoc \
+  --metadata-file=assets/epub-metadata.yaml \
+  --toc --toc-depth=1 \
+  --split-level=1 \
+  --file-scope \
+  --section-divs \
+  -o /tmp/book.epub \
+  $(cat manuscript/Book.txt | sed 's|^|/tmp/epub-build/|' | tr '\n' ' ')
+```
+
+3. **Post-process** the EPUB to fix navigation structure:
+   - Remove `title_page.xhtml` (pandoc auto-generates this; our `titlepage.md` replaces it)
+   - Remove it from `content.opf` manifest and spine
+   - Rewrite `nav.xhtml`: title "Contents", Hours nested under Parts, bodymatter landmark pointing to Preface
+   - Rewrite `toc.ncx` with matching nested structure and correct UUID
+   - Add `<reference type="text">` to guide element for start-reading position
+
+4. **Repackage** (mimetype must be first, uncompressed):
+
+```bash
+zip -X -0 book.epub mimetype
+zip -X -9 -r book.epub META-INF EPUB
+```
+
+5. **Validate:**
+
+```bash
+epubcheck book.epub
+```
+
+### Cover image (uploaded separately to KDP)
+
+```bash
+brew install librsvg
+pip3 install Pillow
+rsvg-convert -w 1600 -h 2560 assets/covers/concept-b-revised.svg | \
+  python3 -c "from PIL import Image; import sys; \
+  Image.open(sys.stdin.buffer).convert('RGB').save('cover-kdp.jpg','JPEG',quality=95)"
+```
+
+### Kindle conversion test
+
+```bash
+brew install --cask calibre
+ebook-convert book.epub book.azw3 --pretty-print
+```
+
 ## How to contribute
 
 Readers, ask your question or (respectfully) challenge existing content by creating an issue on [the Issues tab][4].

--- a/assets/epub-metadata.yaml
+++ b/assets/epub-metadata.yaml
@@ -5,8 +5,6 @@ author:
   - Marty Chang
   - Coraline Chang
 lang: en-US
-rights: All rights reserved
-publisher: Mission H LLC
 description: |
   The church had two thousand years to carry the mission Jesus started.
   It chose power instead. But this generation has something no previous

--- a/manuscript/Book.txt
+++ b/manuscript/Book.txt
@@ -1,7 +1,5 @@
-halftitle.md
 titlepage.md
 copyright.md
-toc.md
 preface.md
 part1.md
 ch01-god.md

--- a/manuscript/copyright.md
+++ b/manuscript/copyright.md
@@ -2,14 +2,12 @@
 
 Christianity in 24 Hours
 
-Copyright © 2026 Mission H LLC. All rights reserved.
+Copyright © 2026 Marty Chang. All rights reserved.
 
-No part of this book may be reproduced in any form without written permission from the publisher, except as permitted by U.S. copyright law.
+No part of this book may be reproduced in any form without written permission from the copyright holder, except as permitted by U.S. copyright law.
 
 The full text of this book is available free at christianity.trusthumankind.org
 
 Unless otherwise noted, all Scripture quotations are from the ESV® Bible (The Holy Bible, English Standard Version®), copyright © 2001 by Crossway, a publishing ministry of Good News Publishers. Used by permission. All rights reserved.
-
-Published by Mission H LLC
 
 First edition, 2026

--- a/manuscript/titlepage.md
+++ b/manuscript/titlepage.md
@@ -3,5 +3,3 @@
 *One story. One decision.*
 
 **Marty Chang & Coraline Chang**
-
-Mission H LLC


### PR DESCRIPTION
## Summary

- Document the repeatable EPUB build process in README (prep → pandoc → post-process → repackage → validate → cover → Kindle test)
- Remove halftitle and manual TOC from Book.txt (EPUB nav handles TOC; halftitle replaced by titlepage as first content page)
- Copyright assigned to Marty Chang (not Mission H LLC)
- Title page: remove publisher line
- epub-metadata.yaml: remove publisher and rights fields (cover uploaded separately to KDP)

## Test plan

- [ ] README build instructions are clear and complete
- [ ] Book.txt produces correct chapter order without halftitle/toc
- [ ] Copyright and title page read correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)