### PR TITLE
fix: remove Preface from TOC and force part pages to recto

### DIFF
--- a/assets/print-template.typ
+++ b/assets/print-template.typ
@@ -147,10 +147,10 @@
           }
         }
 
-        // Part divider
+        // Part divider — always starts on a right-hand (recto) page
         if n == 4 or n == 11 or n == 18 or n == 25 {
 
-          pagebreak(weak: true)
+          pagebreak(to: "odd")
           align(center + horizon)[
             #text(size: 20pt, weight: "bold")[#it.body]
           ]
@@ -201,8 +201,8 @@
   show outline.entry.where(level: 1): it => context {
     let all-h1s = query(heading.where(level: 1))
     let idx = all-h1s.position(h => h.location() == it.element.location())
-    if idx == none or idx < 2 { return }
-    let section-headings = (2, 3, 10, 17, 24, 31, 32)
+    if idx == none or idx < 3 { return }
+    let section-headings = (3, 10, 17, 24, 31, 32)
     if idx in section-headings { it } else { pad(left: 1.5em, text(weight: "regular", it)) }
   }
 


### PR DESCRIPTION
## Summary
Two print proof feedback fixes from Marty's review of the first physical proof:

- **Strike Preface from TOC** (Trello: j508788u) — Preface appears before the table of contents in the book, so listing it in the TOC is redundant. Changed outline entry filter from `idx < 2` to `idx < 3`.
- **Part separators on right-hand pages** (Trello: HAzBUAc1) — Part dividers now use `pagebreak(to: "odd")` so they always start on a recto (right-hand) page with a blank verso (back).

## Verification
- Build: 222 pages (was 221, +1 from blank back pages)
- TOC starts at "Part I — The Foundation" (no Preface line)
- All four parts land on odd page numbers (5, 53, 111, 165)

🤖 Generated with [Claude Code](https://claude.com/claude-code)