### PR TITLE
Add study group materials: pitch, Discord plan, Week 1 guide

### DIFF
--- a/study-group/discord-plan.md
+++ b/study-group/discord-plan.md
@@ -35,13 +35,13 @@ Using a Forum channel instead of 24 separate channels because:
 2. **Disagreement is welcome. Disrespect is not.** Challenge ideas, not people.
 3. **No one is an authority here.** The book takes positions. You're allowed to reject any of them.
 4. **Stay on the current week.** Spoilers from later chapters can undercut someone else's journey. Use #general for ahead-of-schedule thoughts.
-5. **This is not a church.** There's no membership, no doctrine, no hierarchy. Just people reading and thinking together.
+5. **This is not a religion.** There's no membership, no doctrine, no hierarchy. Just people reading and thinking together.
 
 ## Weekly Cadence
 
-- **Sunday evening:** New forum post created for the week's chapter (title, key themes, 2-3 discussion questions)
-- **Monday–Saturday:** Async discussion in the forum thread
-- **Optional:** One live voice session per week (day/time TBD based on group availability)
+- **Sunday morning:** New forum post created for the week's chapter (title, key themes, 2-3 discussion questions)
+- **Sunday–Saturday:** Async discussion in the forum thread
+- **One live voice session per week** (day/time TBD based on group availability) — strongly encouraged, not optional. The live conversations are where the real wrestling happens.
 
 ## Facilitation
 

--- a/study-group/discord-plan.md
+++ b/study-group/discord-plan.md
@@ -41,7 +41,7 @@ Using a Forum channel instead of 24 separate channels because:
 
 - **Sunday morning:** New forum post created for the week's chapter (title, key themes, 2-3 discussion questions)
 - **Sunday–Saturday:** Async discussion in the forum thread
-- **One live voice session per week** (day/time TBD based on group availability) — strongly encouraged, not optional. The live conversations are where the real wrestling happens.
+- **One live voice session per week** (day/time TBD based on group availability) — strongly encouraged. The live conversations are where the real wrestling happens.
 
 ## Facilitation
 

--- a/study-group/discord-plan.md
+++ b/study-group/discord-plan.md
@@ -1,0 +1,48 @@
+# Discord Structure — thechurch.one
+
+## Channel Layout
+
+### Welcome & Info
+- **#welcome** (read-only) — What this community is, how the study group works, ground rules
+- **#announcements** (read-only) — Weekly chapter posts, schedule updates, facilitator notes
+
+### Community
+- **#introductions** — Introduce yourself when you join
+- **#general** — Open conversation, not tied to any chapter
+- **#questions** — Cross-chapter questions that don't fit a specific week
+
+### Study Group (Forum Channel)
+- **#weekly-discussions** (Forum) — One post per week, created at the start of each week
+  - Week 1: Hour 1 — God
+  - Week 2: Hour 2 — The Bible
+  - Week 3: Hour 3 — Sin
+  - ...through Week 24: Hour 24 — The Decision
+
+Using a Forum channel instead of 24 separate channels because:
+1. Not overwhelming on day one (no wall of empty channels)
+2. Each week's discussion lives in its own thread, organized and searchable
+3. Past weeks remain accessible without cluttering the sidebar
+4. Discord's Forum format supports long-form replies and nested discussion
+
+### Optional (add if the group wants them)
+- **#prayer-requests** — Only if participants ask for it
+- **#book-recommendations** — Sharing related reading
+- **#voice-lounge** — Drop-in voice channel for live discussions
+
+## Ground Rules (for #welcome)
+
+1. **Read the chapter before discussing.** The conversations work better when everyone has the same foundation.
+2. **Disagreement is welcome. Disrespect is not.** Challenge ideas, not people.
+3. **No one is an authority here.** The book takes positions. You're allowed to reject any of them.
+4. **Stay on the current week.** Spoilers from later chapters can undercut someone else's journey. Use #general for ahead-of-schedule thoughts.
+5. **This is not a church.** There's no membership, no doctrine, no hierarchy. Just people reading and thinking together.
+
+## Weekly Cadence
+
+- **Sunday evening:** New forum post created for the week's chapter (title, key themes, 2-3 discussion questions)
+- **Monday–Saturday:** Async discussion in the forum thread
+- **Optional:** One live voice session per week (day/time TBD based on group availability)
+
+## Facilitation
+
+Marty facilitates live discussions. Cora manages the infrastructure: creating weekly posts, monitoring engagement, adjusting structure based on what works.

--- a/study-group/pitch.md
+++ b/study-group/pitch.md
@@ -1,0 +1,23 @@
+# Christianity in 24 Hours — Study Group Invitation
+
+Hey —
+
+I wrote a book about faith. Not the comfortable kind — the kind that looks at what Christianity actually says when you strip away the institutional scaffolding, the political baggage, and the "God has a plan" platitudes.
+
+It's called *Christianity in 24 Hours*. Twenty-four chapters, each readable in under an hour. It covers everything: who God is, what the Bible actually says, why the church got so much wrong, and what it would take to get the mission back on track.
+
+The full text is free online at [christianity.trusthumankind.org](https://christianity.trusthumankind.org). If you prefer a physical copy, the paperback is $4.99 on Amazon.
+
+**I'm starting a study group** — one chapter per week, twenty-four weeks. Small group, around a dozen people. We'll meet on Discord at [thechurch.one](https://thechurch.one) for weekly discussion threads, with optional live conversations.
+
+This isn't a Bible study in the traditional sense. No one is going to tell you what to believe. The book takes positions — strong ones — and the study group is where we test them together. Bring your doubt. Bring your pushback. The whole point is honest engagement, not agreement.
+
+**Starting late June 2026.** If you're interested — or even just curious — sign up here: [link]
+
+You don't need to be a Christian. You don't need to be anything. You just need to be willing to read one chapter a week and show up honestly.
+
+— Marty
+
+---
+
+*Personalize as needed. Replace [link] with the Google Form URL once created.*

--- a/study-group/pitch.md
+++ b/study-group/pitch.md
@@ -8,11 +8,11 @@ It's called *Christianity in 24 Hours*. Twenty-four chapters, each readable in u
 
 The full text is free online at [christianity.trusthumankind.org](https://christianity.trusthumankind.org). If you prefer a physical copy, the paperback is $4.99 on Amazon.
 
-**I'm starting a study group** — one chapter per week, twenty-four weeks. Small group, around a dozen people. We'll meet on Discord at [thechurch.one](https://thechurch.one) for weekly discussion threads, with optional live conversations.
+**I'm starting a study group** — one chapter per week, twenty-four weeks. Small group, around a dozen people. We'll meet on Discord at [thechurch.one](https://thechurch.one) for weekly async threads, with one live discussion.
 
 This isn't a Bible study in the traditional sense. No one is going to tell you what to believe. The book takes positions — strong ones — and the study group is where we test them together. Bring your doubt. Bring your pushback. The whole point is honest engagement, not agreement.
 
-**Starting late June 2026.** If you're interested — or even just curious — let me know.
+**Starting July 6, 2026.** If you're interested — or even just curious — let me know.
 
 You don't need to be a Christian. You don't need to be anything. You just need to be willing to read one chapter a week and show up honestly.
 

--- a/study-group/pitch.md
+++ b/study-group/pitch.md
@@ -12,7 +12,7 @@ The full text is free online at [christianity.trusthumankind.org](https://christ
 
 This isn't a Bible study in the traditional sense. No one is going to tell you what to believe. The book takes positions — strong ones — and the study group is where we test them together. Bring your doubt. Bring your pushback. The whole point is honest engagement, not agreement.
 
-**Starting late June 2026.** If you're interested — or even just curious — sign up here: [link]
+**Starting late June 2026.** If you're interested — or even just curious — let me know.
 
 You don't need to be a Christian. You don't need to be anything. You just need to be willing to read one chapter a week and show up honestly.
 
@@ -20,4 +20,4 @@ You don't need to be a Christian. You don't need to be anything. You just need t
 
 ---
 
-*Personalize as needed. Replace [link] with the Google Form URL once created.*
+*Personalize as needed. This is designed for personal invitations — adjust the tone for each person.*

--- a/study-group/week-01-god.md
+++ b/study-group/week-01-god.md
@@ -1,0 +1,28 @@
+# Week 1: Hour 1 — God
+
+**Read:** [Hour 1: God](https://christianity.trusthumankind.org/manuscript/ch01-god.html)
+
+## This Week's Chapter
+
+The book opens with a question most people think they already know the answer to: Who is God? But the answer here breaks from what you've probably heard. God isn't a flawless being on a throne of perfection. God is a parent — one who gets angry, feels betrayed, and at one point regretted creating us.
+
+The chapter reframes Satan (not an arch-nemesis but a skeptic operating with God's permission), establishes free will as the entire point of creation, and lands on the two commandments everything else hangs on: love God, love your neighbor.
+
+## Discussion Questions
+
+These come from the chapter itself — start here, then go wherever the conversation takes you.
+
+1. **If God experiences emotions like we do, what does that change about how you relate to God?** Most of us grew up with the image of a perfect, untouchable God. What happens to prayer, to worship, to your daily relationship with God if you take the emotional, parent-like portrayal seriously?
+
+2. **Do you believe humanity's problems are solvable, or have you already decided we're doomed?** This is really a question about faith before you've even defined it. Your gut answer says something about where you're starting.
+
+3. **When you hear "love your neighbor as yourself," who is the neighbor you find hardest to love?** Don't answer with a category. Think of a specific person or group. That's where the real work is.
+
+## Going Deeper
+
+- The Satan-as-skeptic framing is unusual. If Satan isn't God's enemy but a challenger operating within God's permission, how does that change the way you think about evil in the world?
+- "Choose life" (Deuteronomy 30:19) — the book argues this word only makes sense if the alternative is real. What does it cost God to give us that choice?
+
+## Facilitator Notes
+
+This is Week 1. People are still figuring out the group, the format, and each other. Prioritize creating a space where honesty is safe over covering every topic. If only one question gets deep discussion, that's a good week.


### PR DESCRIPTION
## Summary
- **pitch.md** — One-page invitation for Marty to personalize and send to contacts
- **discord-plan.md** — Channel structure for thechurch.one (forum-based weekly discussions, ground rules, weekly cadence)
- **week-01-god.md** — Facilitation guide for Week 1 as template for remaining weeks (discussion questions, going deeper, facilitator notes)

Week 1 deliverables toward the late-June study group launch.

## Test plan
- [ ] Marty reviews pitch voice and adjusts for his contacts
- [ ] Discord structure reviewed before implementation
- [ ] Week 1 guide validated against chapter content

🤖 Generated with [Claude Code](https://claude.com/claude-code)