### PR TITLE
Add facilitation guides for Weeks 2-6 (Part I)

### DIFF
--- a/study-group/week-02-the-bible.md
+++ b/study-group/week-02-the-bible.md
@@ -1,0 +1,26 @@
+# Week 2: Hour 2 — The Bible
+
+**Read:** [Hour 2: The Bible](https://christianity.trusthumankind.org/manuscript/ch02-the-bible.html)
+
+## This Week's Chapter
+
+What is the Bible? Not a rulebook, not a contract, not a single document with a single message. It's a library — 66 books by roughly 40 authors across 1,500 years. The chapter argues that the diversity isn't a flaw; it's the point. Multiple perspectives, genres, and centuries of context produce a richer picture of God and the mission than any single voice could.
+
+The chapter also takes on how we misuse the Bible: cherry-picking verses, treating it as a legal code, and ignoring context. The remedy is simple and demanding — read whole books, not isolated verses. Read with the mission in mind: if your interpretation leads away from love, justice, mercy, and humility, re-examine it.
+
+## Discussion Questions
+
+1. **When was the last time you read a full book of the Bible — not a verse, not a chapter, but an entire book?** If the answer is "never," what has been stopping you? If you have, what was different about reading it whole versus reading pieces?
+
+2. **Have you ever used a Bible verse to justify something you wanted to do?** Be honest. What would happen if you went back and read the full context of that verse?
+
+3. **What part of the Bible makes you most uncomfortable?** The chapter argues that's probably where you should start. Why do we avoid the parts that challenge us?
+
+## Going Deeper
+
+- The chapter says the Bible is not a legally binding contract. If you grew up treating it as one — with rules, penalties, and loopholes — what changes when you read it as a library of voices wrestling with the same questions across centuries?
+- "If your interpretation leads away from love, justice, mercy, and humility, re-examine it." Is this a useful test, or does it risk letting people dismiss any passage they find inconvenient?
+
+## Facilitator Notes
+
+This chapter challenges how people relate to the Bible itself, which can feel personal. Some participants may have deep attachment to specific interpretive traditions. The goal isn't to dismantle anyone's framework — it's to ask whether we've actually engaged the text or just inherited a relationship with it. Let people sit with that question rather than rushing to defend positions.

--- a/study-group/week-03-sin.md
+++ b/study-group/week-03-sin.md
@@ -1,0 +1,26 @@
+# Week 3: Hour 3 — Sin
+
+**Read:** [Hour 3: Sin](https://christianity.trusthumankind.org/manuscript/ch03-sin.html)
+
+## This Week's Chapter
+
+Sin isn't a list of prohibited activities. It's choosing yourself over the mission — every act of indifference, cruelty, or selfishness that adds evidence to the case against humanity. The chapter traces this from the garden forward: God gave us free will, and we immediately used it to prioritize ourselves.
+
+The most provocative claim: the most damaging sin isn't the dramatic kind. It's omission — what you didn't do. Jesus condemns people not for what they did wrong, but for failing to feed the hungry, clothe the naked, and visit the imprisoned. The chapter also argues that morality is objective, not relative. If it were relative, we'd have no grounds to condemn historical atrocities — they'd just be "a difference of opinion."
+
+## Discussion Questions
+
+1. **What is the most recent choice you made where you chose your own comfort over someone else's need?** How did you justify it to yourself? Everyone has an answer to this — the question is whether you'll say it out loud.
+
+2. **Are there sins you've reclassified as "not that bad" because they're common or socially acceptable?** The chapter argues sin isn't relative. What would happen if you called them what they are?
+
+3. **When was the last time you did nothing when you could have done something?** What held you back — fear, inconvenience, or something else? This is the "sin nobody talks about."
+
+## Going Deeper
+
+- The chapter defines sin as choosing yourself over the mission, not as breaking specific rules. Does this broader definition make sin feel more serious or less? Does it make everyone more culpable or does it risk making the word meaningless?
+- If morality is objective and not relative, who gets to define the standard? The chapter says it's grounded in the mission. Is that enough, or does it still leave room for people to define the mission in self-serving ways?
+
+## Facilitator Notes
+
+Sin is the topic most likely to trigger defensiveness. People hear "sin" and brace for judgment. The chapter's reframing — especially the focus on omission — can feel more convicting than a traditional list of don'ts, because no one is off the hook. Let the discomfort sit. If people start deflecting to abstract debates about moral relativism, gently redirect: "What about you, specifically?" The discussion questions are designed to be personal. Trust that.

--- a/study-group/week-04-salvation.md
+++ b/study-group/week-04-salvation.md
@@ -1,0 +1,26 @@
+# Week 4: Hour 4 — Salvation
+
+**Read:** [Hour 4: Salvation](https://christianity.trusthumankind.org/manuscript/ch04-salvation.html)
+
+## This Week's Chapter
+
+If everyone sins, is anyone saved? The answer: either all of us are saved or none of us. Salvation isn't a personal transaction — it's a communal destination. Crossing the finish line alone is "failure with good personal stats."
+
+The chapter rejects penal substitutionary atonement — the idea that Jesus paid a cosmic debt on your behalf. Instead, Jesus lived the mission without faltering and became a proof of concept: the gap between human failure and God's standard can be crossed. Grace means the door stays open after you fail. The Parable of the Sower isn't a permanent sorting system for four types of people — it's a diagnostic. The same person can be rocky ground at twenty and good soil at forty. The question is what's choking the seed right now.
+
+## Discussion Questions
+
+1. **If salvation is not a one-time event but a long-term goal, how does that change your sense of urgency about how you live today?** Most people either think they're already saved or that it doesn't matter. What if neither is quite right?
+
+2. **After Peter denied him, Jesus responded, "Do you love me? Then keep going." What would you want to hear after your worst failure?** What would it change to hear that the mission still needs you?
+
+3. **What is choking the seed in your life right now — comfort, fear, busyness, cynicism?** Name it honestly. The Parable of the Sower is a diagnostic, not a verdict. What's your diagnosis?
+
+## Going Deeper
+
+- The chapter argues that salvation is inherently communal — either all of us or none of us. How does that sit with the way most people think about their personal relationship with God? What does it demand of you toward people you'd rather leave behind?
+- If Jesus is a "proof of concept" rather than a substitute who paid your debt, what changes about the relationship between you and the cross? Does it ask more of you or less?
+
+## Facilitator Notes
+
+This chapter directly challenges a core doctrine many Christians grew up with (substitutionary atonement). Some participants may feel the book is dismissing something sacred to them. It's worth naming that tension explicitly: "This is a strong position. You're allowed to reject it. But engage with the argument before you decide." The Sower diagnostic (Question 3) tends to open people up — it's self-reflective without being accusatory. If the group is tense from the theological challenge, lean into that question.

--- a/study-group/week-05-faith.md
+++ b/study-group/week-05-faith.md
@@ -1,0 +1,26 @@
+# Week 5: Hour 5 — Faith
+
+**Read:** [Hour 5: Faith](https://christianity.trusthumankind.org/manuscript/ch05-faith.html)
+
+## This Week's Chapter
+
+Faith is not belief. Demons believe in God — it doesn't save them. Faith is the active, daily choice to carry the mission even when it costs you something. It's not a decision you make once; it's a direction you walk in every day.
+
+The chapter's sharpest distinction: doubt is not the opposite of faith — indifference is. The father who cried "I believe; help my unbelief!" is what faith sounds like in practice, and Jesus honored it. Faith doesn't require confident certainty. It requires choosing the mission despite uncertainty. And faith is what gives the edge for sustainable selflessness — without it, you must claw for one more day and protect yourself at all costs. With it, you can give your days away.
+
+## Discussion Questions
+
+1. **What would you do differently tomorrow if you truly believed the material stakes of this life are not the final stakes?** Not abstractly — tomorrow. What specific choice would change?
+
+2. **When was the last time your faith cost you something — comfort, money, reputation, relationships?** If you can't think of an example, what does that tell you?
+
+3. **Do you treat faith as a decision you made once, or as a direction you're walking in every day?** What's the difference in practice? What does daily faith actually look like in your life?
+
+## Going Deeper
+
+- "I believe; help my unbelief!" — the chapter calls this an honest expression of faith, not a failure of it. If doubt is compatible with faith, what actually disqualifies someone? Where's the line between honest struggle and giving up?
+- The chapter argues that faith enables sustainable selflessness because it changes the stakes. Without eternal stakes, self-preservation is rational. Is this a genuine insight or a crutch? Can someone without faith be just as selfless?
+
+## Facilitator Notes
+
+Faith is the most personally exposing topic so far. The first four chapters were about God, the Bible, sin, and salvation — largely external. This one turns inward: do you actually live what you say you believe? Question 2 is the sharpest — if no one can name a time their faith cost them something, that silence is the discussion. Don't fill it. Let people sit with it. This is also a good week to check in on the group dynamic: by Week 5, patterns are forming. Who talks, who doesn't, who's engaging the reading.

--- a/study-group/week-06-holy-spirit.md
+++ b/study-group/week-06-holy-spirit.md
@@ -1,0 +1,26 @@
+# Week 6: Hour 6 — The Holy Spirit
+
+**Read:** [Hour 6: The Holy Spirit](https://christianity.trusthumankind.org/manuscript/ch06-holy-spirit.html)
+
+## This Week's Chapter
+
+The Holy Spirit's dramatic supernatural activity — tongues, healings, prophecy — was specific to the early church. Uneducated fishermen needed credibility and courage to build a global movement against the Roman Empire. That job is done. What we have now is the completed Bible and a character standard to live by.
+
+The chapter's most confrontational claim: "God told me" is usually confirmation bias wearing religious costume. If God is personally directing individual decisions through the Spirit, then the test of free will is rigged — either our choices are ours or they aren't. The Spirit's legacy isn't an ongoing whisper in your ear. It's the fruit of the Spirit — love, joy, peace, patience, kindness, goodness, faithfulness, gentleness, self-control — developed through discipline and daily choice, not supernatural intervention.
+
+## Discussion Questions
+
+1. **Have you ever said "God told me" or "the Spirit led me"?** What were you actually describing — divine communication, or a strong feeling you wanted to validate? This isn't a trick question. It's worth being honest about.
+
+2. **If the Spirit is not actively guiding you today, does that change how you make decisions?** Does it make your faith more demanding or less? What does decision-making look like without a divine nudge?
+
+3. **Look at the fruit of the Spirit — love, joy, peace, patience, kindness, goodness, faithfulness, gentleness, self-control.** Which of these do you practice because you choose to, and which do you wait to "feel led" toward?
+
+## Going Deeper
+
+- The chapter argues that claiming ongoing supernatural guidance undermines free will — the entire point of creation. But for many believers, the Spirit's presence is the most intimate part of their faith. Is there a way to hold both, or are they genuinely incompatible?
+- If the fruit of the Spirit is developed through discipline rather than received through supernatural gifting, what distinguishes a Christian practicing patience from a non-Christian practicing patience? Does the distinction matter?
+
+## Facilitator Notes
+
+This is the end of Part I — the foundation chapters. It's also likely the most controversial chapter so far for charismatic or Pentecostal participants, and potentially liberating for people who've felt guilty about never "hearing God's voice." Both reactions are valid. The "Going Deeper" questions are designed to hold that tension without resolving it — let the group wrestle. This is also a natural checkpoint: consider asking the group how the format is working and whether the pacing feels right before moving into Part II.


### PR DESCRIPTION
## Summary
- Facilitation guides for the remaining Part I chapters: Bible, Sin, Salvation, Faith, Holy Spirit
- Each follows the Week 1 template: chapter summary, 3 discussion questions (drawn from the chapter's own "Questions to sit with"), 2 "Going Deeper" prompts, facilitator notes
- Gives the study group 6 weeks of runway at the July 6 launch

## Files
- `study-group/week-02-the-bible.md`
- `study-group/week-03-sin.md`
- `study-group/week-04-salvation.md`
- `study-group/week-05-faith.md`
- `study-group/week-06-holy-spirit.md`

## Notes for review
- Discussion questions are the chapter's own, lightly reframed for group conversation
- Facilitator notes flag likely tension points (e.g., Week 4's challenge to substitutionary atonement, Week 6's position on the Spirit)
- Week 6 includes a natural checkpoint prompt — end of Part I, good time to check group format/pacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)