### PR TITLE
Add invitation variants and Discord welcome content

### DIFF
--- a/study-group/invitation-variants.md
+++ b/study-group/invitation-variants.md
@@ -32,7 +32,7 @@ All variants link to the same resources:
 >
 > I know you're not religious, and that's exactly why I'm reaching out.
 >
-> I wrote a book called *Christianity in 24 Hours*. It's not what you'd expect — it argues that most of what people associate with Christianity (the politics, the judgment, the prosperity gospel) is a distortion of the actual message. The real mission is simpler and harder: love God, love your neighbor, and build a world where both are possible.
+> I wrote a book called *Christianity in 24 Hours*. It's not what you'd expect — it argues that most of what people associate with Christianity (the politics, the judgment, the prosperity gospel) is a distortion of the actual message. The real mission is simpler and harder: reducing violence, ending poverty, fighting injustice, and building a world that's fair and equitable for everyone. You and I already share that goal — we just come at it from different starting points.
 >
 > I'm starting a study group — one chapter a week for 24 weeks, starting July 6. You don't need to be a Christian. You don't need to believe anything. The group exists to test the book's arguments honestly, and skepticism is more useful than agreement.
 >

--- a/study-group/invitation-variants.md
+++ b/study-group/invitation-variants.md
@@ -1,0 +1,75 @@
+# Personalized Invitation Variants
+
+The [pitch](pitch.md) is the general-purpose version. These variants adjust tone and emphasis for different audiences. Each is designed for personal text, email, or DM — not mass distribution.
+
+All variants link to the same resources:
+- Free online: [christianity.trusthumankind.org](https://christianity.trusthumankind.org)
+- Paperback: $4.99 on Amazon
+- Discord: [thechurch.one](https://thechurch.one)
+- Start date: **July 6, 2026**
+
+---
+
+## For Christian Friends
+
+> Hey [Name] —
+>
+> I wrote a book about Christianity. Fair warning: it's not comfortable. It challenges a lot of what we grew up hearing — substitutionary atonement, the Spirit as a personal guidance system, the idea that salvation is an individual transaction. I think the mission got buried under centuries of institutional scaffolding, and the book tries to dig it back out.
+>
+> I'm starting a study group — one chapter a week for 24 weeks, starting July 6. Small group, maybe a dozen people. We meet on Discord for weekly discussion threads and one live conversation.
+>
+> I want people in this group who will push back. You know the tradition well enough to challenge me where I'm wrong. That's exactly what I need.
+>
+> The book is free online at christianity.trusthumankind.org. Let me know if you're interested.
+>
+> — Marty
+
+---
+
+## For Secular / Skeptic Friends
+
+> Hey [Name] —
+>
+> I know you're not religious, and that's exactly why I'm reaching out.
+>
+> I wrote a book called *Christianity in 24 Hours*. It's not what you'd expect — it argues that most of what people associate with Christianity (the politics, the judgment, the prosperity gospel) is a distortion of the actual message. The real mission is simpler and harder: love God, love your neighbor, and build a world where both are possible.
+>
+> I'm starting a study group — one chapter a week for 24 weeks, starting July 6. You don't need to be a Christian. You don't need to believe anything. The group exists to test the book's arguments honestly, and skepticism is more useful than agreement.
+>
+> The full text is free at christianity.trusthumankind.org. If you're curious, let me know.
+>
+> — Marty
+
+---
+
+## For Intellectually Curious / Academic Friends
+
+> Hey [Name] —
+>
+> I finished a book I've been working on for a while — *Christianity in 24 Hours*. Twenty-four chapters covering God, Scripture, sin, salvation, the church's history, and where the mission goes from here. It's a theological argument, not devotional reading. The book takes positions and defends them, and some of them (morality is objective, the Spirit isn't actively guiding individuals today, salvation is communal or it's nothing) will probably start arguments.
+>
+> I'm putting together a study group — one chapter per week, 24 weeks, starting July 6. Small group on Discord. The format is async written discussion plus one live conversation per week. I want people who engage with ideas seriously, whether or not they agree with the conclusions.
+>
+> The text is free at christianity.trusthumankind.org. Let me know if this is your kind of thing.
+>
+> — Marty
+
+---
+
+## For Family
+
+> Hey [Name] —
+>
+> You know I've been writing this book about faith. It's done — *Christianity in 24 Hours*. I'm proud of it, and I'd love for you to read it, but more than that, I'd love to talk about it with you.
+>
+> I'm starting a study group — one chapter a week for 24 weeks, starting July 6. Small group, about a dozen people. We meet on Discord (I'll help you set it up if you need). Each week there's a discussion thread and one live conversation.
+>
+> This isn't me preaching. The book takes strong positions and the group exists to challenge them. I want your honest reaction, not your politeness.
+>
+> The book is free online at christianity.trusthumankind.org, or I can send you a copy. Let me know.
+>
+> — Marty
+
+---
+
+*Notes for Marty: These are starting points. The best invitation is one that references something specific about your relationship with the person — a conversation you've had, a question they've asked, a disagreement you've never resolved. The template gets you started; the personal detail makes them say yes.*

--- a/study-group/welcome-content.md
+++ b/study-group/welcome-content.md
@@ -1,0 +1,79 @@
+# Discord Welcome Content
+
+## #welcome Channel
+
+*This is the read-only welcome message new members see when they join thechurch.one.*
+
+---
+
+**Welcome to thechurch.one.**
+
+This is a study group for *Christianity in 24 Hours* — a book that asks what Christianity actually says when you strip away the institutional scaffolding, the political baggage, and the comfortable answers.
+
+**How it works:**
+- One chapter per week, 24 weeks
+- Each chapter takes under an hour to read
+- Weekly discussion threads in #weekly-discussions (Forum channel)
+- One live voice session per week (day/time announced in #announcements)
+- The book is free at [christianity.trusthumankind.org](https://christianity.trusthumankind.org)
+
+**Ground rules:**
+
+1. **Read the chapter before discussing.** The conversations work better when everyone has the same foundation.
+2. **Disagreement is welcome. Disrespect is not.** Challenge ideas, not people.
+3. **No one is an authority here.** The book takes positions. You're allowed to reject any of them.
+4. **Stay on the current week.** Spoilers from later chapters can undercut someone else's journey. Use #general for ahead-of-schedule thoughts.
+5. **This is not a religion.** There's no membership, no doctrine, no hierarchy. Just people reading and thinking together.
+
+**Getting started:**
+1. Introduce yourself in #introductions — whatever you're comfortable sharing
+2. Read Hour 1: God ([link](https://christianity.trusthumankind.org/manuscript/ch01-god.html)) before the first week's discussion
+3. Jump into #weekly-discussions when the first thread opens
+
+Questions? Ask in #questions or #general. See you in the discussion.
+
+---
+
+## Welcome DM (sent to new members)
+
+*Automated or manual — sent when someone joins the server.*
+
+---
+
+Hey — welcome to thechurch.one. Glad you're here.
+
+Quick orientation:
+- **#welcome** has the ground rules and how everything works
+- **#introductions** — say hi when you're ready
+- **#weekly-discussions** — this is where the study group happens, one thread per week
+- The book is free at christianity.trusthumankind.org
+
+We start **July 6** with Hour 1: God. No prep needed before then — just read the first chapter when you're ready.
+
+If you have questions, #general is the place.
+
+---
+
+## First Week Forum Post Template
+
+*Posted Sunday morning of Week 1 in #weekly-discussions.*
+
+---
+
+**Week 1: Hour 1 — God**
+
+Read: [Hour 1: God](https://christianity.trusthumankind.org/manuscript/ch01-god.html)
+
+The book opens with a question most people think they already know the answer to: Who is God? The answer breaks from what you've probably heard. God isn't a flawless being on a throne of perfection. God is a parent — one who gets angry, feels betrayed, and at one point regretted creating us.
+
+**Discussion questions:**
+
+1. If God experiences emotions like we do, what does that change about how you relate to God?
+2. Do you believe humanity's problems are solvable, or have you already decided we're doomed?
+3. When you hear "love your neighbor as yourself," who is the neighbor you find hardest to love?
+
+Share your thoughts below. There are no wrong answers — the only expectation is honesty.
+
+---
+
+*The full facilitation guide for each week is in the study-group/ directory (week-01-god.md through week-06-holy-spirit.md). The forum post is a condensed version — summary, questions, and an invitation to engage.*

--- a/study-group/welcome-content.md
+++ b/study-group/welcome-content.md
@@ -2,11 +2,11 @@
 
 ## #welcome Channel
 
-*This is the read-only welcome message new members see when they join thechurch.one.*
+*This is the read-only welcome message new members see when they join **the church**.*
 
 ---
 
-**Welcome to thechurch.one.**
+Welcome to **the church**.
 
 This is a study group for *Christianity in 24 Hours* — a book that asks what Christianity actually says when you strip away the institutional scaffolding, the political baggage, and the comfortable answers.
 
@@ -40,7 +40,7 @@ Questions? Ask in #questions or #general. See you in the discussion.
 
 ---
 
-Hey — welcome to thechurch.one. Glad you're here.
+Hey — welcome to **the church**. Glad you're here.
 
 Quick orientation:
 - **#welcome** has the ground rules and how everything works


### PR DESCRIPTION
## Summary
- Four personalized invitation templates for different audiences: Christian friends, secular/skeptic, intellectual/academic, family
- Discord #welcome channel content with ground rules and getting-started steps
- Welcome DM template for new members joining the server
- First week forum post template (condensed from the facilitation guide)

## Context
Week 2 of the study group timeline (by June 21) focuses on personal outreach. These templates give Marty starting points for each conversation — the note at the bottom reminds him to personalize with something specific to his relationship with each person.

The welcome content can be copy-pasted into Discord once the channels are set up. The forum post template shows the format for weekly discussion threads.

## Files
- `study-group/invitation-variants.md`
- `study-group/welcome-content.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)