### PR TITLE
Add facilitation guides for Weeks 7-12 (Part II)

### DIFF
--- a/study-group/week-07-creation-to-abraham.md
+++ b/study-group/week-07-creation-to-abraham.md
@@ -1,0 +1,26 @@
+# Week 7: Hour 7 — Creation to Abraham
+
+**Read:** [Hour 7: Creation to Abraham](https://christianity.trusthumankind.org/manuscript/ch07-creation-to-abraham.html)
+
+## This Week's Chapter
+
+This is the beginning of Part II — the story. The chapter covers everything from "In the beginning" to the covenant with Abraham: creation, the fall, Cain and Abel, the flood, the Tower of Babel, and the man who said yes when God asked him to leave everything behind.
+
+The argument running through it all: the problem isn't environmental. You can wipe the earth clean with a flood and the capacity to choose self over others survives in every person. That's not a design flaw — it's the design. The test has to be real. And Abraham, the man God chose to build a nation through, was imperfect — he lied about his wife, doubted the promise, slept with Hagar. The Bible doesn't present heroes as paragons. The point is: you don't have to be perfect. You have to keep choosing.
+
+## Discussion Questions
+
+1. **When you read about the flood, do you see a God who gave up or a God who refused to?** What's the difference? This question sets up the rest of the Old Testament — whether you read God's actions as punishment or persistence changes everything.
+
+2. **Abraham left everything familiar on a promise he couldn't verify. What is the most significant thing you've done on faith alone — without proof it would work out?** Not a grand gesture. A real moment where you chose without evidence.
+
+3. **Cain asked "Am I my brother's keeper?" How would you answer that question honestly, based on how you actually live?** Not how you'd answer it in theory. How your daily choices answer it.
+
+## Going Deeper
+
+- The chapter says the flood didn't fix the problem because the problem is internal, not environmental. If external resets don't work, what does? Is the entire arc of the Bible one long answer to that question?
+- God's test with Isaac — the chapter argues God accepted the willingness without requiring the act. What does that say about what God is actually looking for from us? Is willingness enough, or does God eventually ask you to follow through?
+
+## Facilitator Notes
+
+This is the first week of Part II and the first time the group engages sustained narrative rather than theological concepts. Some participants may be unfamiliar with these stories; others may have heard them since childhood. Both reactions are useful — fresh eyes see things habitual readers miss, and habitual readers can identify where their assumptions differ from the text. The Cain question (Question 3) tends to land hard because it's about daily life, not ancient history.

--- a/study-group/week-08-moses-and-the-law.md
+++ b/study-group/week-08-moses-and-the-law.md
@@ -1,0 +1,26 @@
+# Week 8: Hour 8 — Moses and the Law
+
+**Read:** [Hour 8: Moses and the Law](https://christianity.trusthumankind.org/manuscript/ch08-moses-and-the-law.html)
+
+## This Week's Chapter
+
+Why did God give rules people would inevitably break? Because early humanity didn't know how to conduct themselves. Rules are how you teach children — and humanity was a child. You internalize the rules, grow up, and eventually don't need someone handing them to you anymore.
+
+The chapter traces Moses from the burning bush through the Exodus, the Law, the golden calf, forty years of wilderness, and his denial at the boundary of the Promised Land. The sharpest claim: the Law is not the cure — it's the diagnosis. It reveals sin, not to condemn but to show how much growing up humanity still had to do. And no amount of miracles — parted seas, pillars of fire, manna from the sky — is enough to override the human capacity to choose self over mission. Six weeks after the Red Sea parted, Israel built a golden calf.
+
+## Discussion Questions
+
+1. **God gave the Law knowing people would break it. What does that tell you about the purpose of rules — in religion, and in your own life?** Are rules meant to be obeyed perfectly, or are they something else entirely?
+
+2. **The Israelites wanted to go back to slavery rather than face the unknown. Where in your life have you chosen a familiar cage over an uncertain freedom?** This isn't ancient history. This is a pattern.
+
+3. **Moses served faithfully for forty years and was denied entry to the Promised Land for one moment of unfaithfulness. Is that fair? Does "fair" matter?** Let people wrestle with this. The discomfort is the point.
+
+## Going Deeper
+
+- The chapter frames the Law as childhood parenting — explicit rules, clear consequences, constant supervision. If humanity has graduated to adulthood, what replaces the Law? Is the answer already in Part I (faith, the fruit of the Spirit), or is something still missing?
+- The golden calf came six weeks after the Red Sea. What does the proximity of miracle to failure tell you about the relationship between evidence and faith? If miracles don't sustain faithfulness, what does?
+
+## Facilitator Notes
+
+The Moses-denied-entry question (Question 3) tends to split groups. Some find it brutally unfair; others see it as the logical extension of "the standard doesn't bend." Both readings are defensible. If the group gets stuck debating fairness, redirect to the personal: have you ever been held to a standard that felt disproportionate to your failure? How did you respond? The slavery-vs-freedom question (Question 2) can go deep fast — give it space.

--- a/study-group/week-09-the-prophets.md
+++ b/study-group/week-09-the-prophets.md
@@ -1,0 +1,26 @@
+# Week 9: Hour 9 — The Prophets
+
+**Read:** [Hour 9: The Prophets](https://christianity.trusthumankind.org/manuscript/ch09-the-prophets.html)
+
+## This Week's Chapter
+
+The prophets weren't fortune-tellers. They were truth-tellers — people who saw what everyone else saw and said what no one else would say. The chapter traces Israel's cycle: receive the mission, perform the rituals, gut the substance, get called out by someone who tells the truth at personal cost.
+
+The sharpest critique: Israel kept the letter of the Law while abandoning its purpose. They had the Temple, the sacrifices, the feasts, the rituals — and none of the substance. They performed religion without becoming the kind of people religion was designed to produce. Then four hundred years of silence. No prophets, no intervention, no new word from God. The chapter argues this wasn't abandonment — it was the pause between childhood and adulthood.
+
+## Discussion Questions
+
+1. **The prophets told truths that made them unpopular, imprisoned, and sometimes killed. When was the last time you said something true that cost you something?** Not a disagreement that was inconvenient. Something true that had real consequences.
+
+2. **Israel kept the rituals of faith while abandoning its substance. Where in your own life do you perform faithfulness without practicing it?** Church attendance, prayer habits, charitable giving — any of these can be performance. Where is yours?
+
+3. **Four hundred years of prophetic silence separated the Old Testament from the New. If God went silent in your life for that long, would your faith survive?** Most people have experienced some version of this — a season where God felt absent. What did you do with it?
+
+## Going Deeper
+
+- The chapter says prophecy is truth-telling, not prediction. If that's true, who are the prophets today? What does it look like to speak unwelcome truth in a culture that punishes it with social exile rather than physical violence?
+- Israel was given special treatment (miracles, direct intervention) during its adolescence, but the chapter argues that treatment wasn't meant to be permanent. What changes in your relationship with God when you accept that the age of miracles was a phase, not the norm?
+
+## Facilitator Notes
+
+The ritual-vs-substance question (Question 2) can feel personally exposing, especially for participants with strong church backgrounds. Some may feel defensive. That's useful — defensiveness often marks the exact spot where the question landed. The silence question (Question 3) can surface real grief. If someone shares a season of feeling abandoned by God, don't rush to resolve it. Sit with it. That's the kind of honesty the group exists for.

--- a/study-group/week-10-jesus-the-life.md
+++ b/study-group/week-10-jesus-the-life.md
@@ -1,0 +1,26 @@
+# Week 10: Hour 10 — Jesus: The Life
+
+**Read:** [Hour 10: Jesus — The Life](https://christianity.trusthumankind.org/manuscript/ch10-jesus-the-life.html)
+
+## This Week's Chapter
+
+Who was Jesus? The person who showed humanity what faithfulness looks like — lived, not legislated. The chapter covers his teaching, his parables, how he lived, who he challenged, and what he refused to do.
+
+Jesus moved faithfulness from rules to character, from external compliance to internal conviction. The Law said "don't murder"; Jesus said "don't nurture the anger that produces murder." The problem isn't the act — it's the desire you're feeding. He also reserved his sharpest criticism for the religious establishment, not sinners. The Pharisees tithed their spice racks while ignoring justice, mercy, and faithfulness. This is the prophets' message delivered in person.
+
+## Discussion Questions
+
+1. **Jesus said the problem isn't the act but the desire behind it. What desire in your life would you rather not examine?** Not your worst behavior — the thing underneath it. The resentment, the envy, the need for control. Name it.
+
+2. **The rich young man walked away because the cost was too high. What would you walk away from if Jesus asked you to give it up?** Everyone has a thing they'd protect at the expense of the mission. What's yours?
+
+3. **Jesus's sharpest words were for religious leaders, not sinners. What does that tell you about who is in the most danger of missing the point?** If you've been in church your whole life, this question is for you.
+
+## Going Deeper
+
+- Jesus refused to establish an earthly kingdom or use his gifts to protect himself. He rejected the role people wanted him to play. Where do you see Christians today trying to build the political kingdom Jesus explicitly refused?
+- The parables are designed to land differently depending on who's listening. Which parable has changed meaning for you as your life has changed? What shifted?
+
+## Facilitator Notes
+
+This is the Jesus chapter people have been waiting for — or dreading. Some participants will have strong existing relationships with Jesus; others will be encountering him seriously for the first time. The desire question (Question 1) goes deeper than behavior, which can feel vulnerable. The rich-young-man question (Question 2) works because everyone knows their answer even if they don't want to say it. If the group is mostly churched, lean hard into Question 3 — the challenge to religious insiders is the chapter's sharpest edge.

--- a/study-group/week-11-jesus-death-resurrection.md
+++ b/study-group/week-11-jesus-death-resurrection.md
@@ -1,0 +1,28 @@
+# Week 11: Hour 11 — Jesus: Death and Resurrection
+
+**Read:** [Hour 11: Jesus — Death and Resurrection](https://christianity.trusthumankind.org/manuscript/ch11-jesus-death-resurrection.html)
+
+## This Week's Chapter
+
+Why did Jesus have to die? He didn't have to. He chose to. And that choice is the point.
+
+The chapter walks through the last days, Gethsemane, the arrest, the trial, the cross, and the resurrection. The central argument: Jesus's death proves the mission is possible — not that God requires blood or that humanity owes a cosmic debt. When faced with the ultimate cost, he chose the mission anyway. In Gethsemane, he asked God three times to take the cup from him. He did not want to die. That detail is critical: if Jesus accepted death with divine serenity, it wouldn't mean anything. The test of faithfulness is only real if the alternative is real.
+
+The resurrection is God's confirmation: this is the way. This refusal to choose self even when self-preservation was the only sane option — this is what I was looking for since Genesis 1.
+
+## Discussion Questions
+
+1. **Jesus asked God to take the cup from him. What does it mean for your faith that even Jesus didn't want to suffer?** If the person who lived the mission perfectly still asked for a way out, what does that say about your own reluctance?
+
+2. **The cross proves the mission is possible. Does that make it easier or harder to explain why you haven't carried it?** This question has teeth. Sit with it before answering.
+
+3. **Peter denied Jesus three times and was still the one Jesus chose to build the church on. What does that say about the role of failure in faith?** Your worst moment doesn't disqualify you. But does knowing that make it easier to try, or easier to excuse your failures?
+
+## Going Deeper
+
+- The chapter explicitly rejects the idea that Jesus died to pay a cosmic debt (penal substitutionary atonement). If you grew up with that framework, what changes when you read the cross as a choice rather than a transaction? Does the cross ask more of you or less?
+- The resurrection is presented as God's confirmation, not as proof of divinity. What's the difference? And what does it mean for how you relate to the resurrection — as a miracle to believe in or as a direction to follow?
+
+## Facilitator Notes
+
+This is likely the most emotionally charged week in Part II. The cross is sacred ground for many participants. The chapter's rejection of substitutionary atonement may have already surfaced in Week 4 (Salvation), but encountering it again in the narrative — at the moment of crucifixion — hits differently. Give people room to process. Question 2 is the sharpest in the study group so far. Don't soften it. If the silence after it is long, that's the discussion happening.

--- a/study-group/week-12-the-early-church.md
+++ b/study-group/week-12-the-early-church.md
@@ -1,0 +1,28 @@
+# Week 12: Hour 12 — The Early Church
+
+**Read:** [Hour 12: The Early Church](https://christianity.trusthumankind.org/manuscript/ch12-the-early-church.html)
+
+## This Week's Chapter
+
+What happened after Jesus left? A handful of ordinary people tried to live the mission. They failed constantly and changed the world anyway.
+
+The chapter traces the early church from Pentecost through Paul's missionary journeys, the struggles, persecution, and growth. The early church was not a utopia — Ananias and Sapphira wanted the reputation of generosity without the cost. But imperfect people can carry the mission. You don't need to be worthy; you need to be willing.
+
+The most striking claim: a movement with no political power, no military backing, no institutional infrastructure, and no wealthy patrons — actively being destroyed by the most powerful empire on earth — survived and expanded because they lived differently. They made people ask: what do they have that I don't?
+
+## Discussion Questions
+
+1. **The early church shared everything they had. What would it take for you to live like that — and what stops you?** Not "would you" — what specifically prevents it? Name the barrier.
+
+2. **Paul went from persecuting Christians to dying for the mission. What does his transformation say about the possibility of your own?** If the most hostile enemy of the faith can become its greatest champion, what excuse do you have?
+
+3. **The early church grew during persecution, not despite it. What does that suggest about the relationship between comfort and faithfulness?** Look at your own life. When were you most faithful — in comfort or in difficulty?
+
+## Going Deeper
+
+- The dramatic gifts of the Spirit (languages, healing, boldness) were concentrated in the earliest years and faded as the church matured. If this is true, the church was never meant to run on miracles — it was meant to run on the mission, lived out by ordinary people. Does your experience of church match that, or does it still chase the dramatic?
+- Ananias and Sapphira wanted the reputation of generosity without the cost. Where do you see that pattern in modern Christianity — or in your own life? What's the difference between genuine generosity and performed generosity?
+
+## Facilitator Notes
+
+This is the end of Part II — the midpoint of the study group. Take a moment to acknowledge what the group has covered: the theology (Part I), the story (Part II). The second half shifts to application. This is a natural checkpoint: ask how the group is doing. Is the pacing right? Is the format working? Are the live discussions adding value? Make space for that meta-conversation. On the content itself: Question 1 (sharing everything) tends to generate the most debate. Let it run — the tension between the ideal and the practical is exactly where the real discussion lives.


### PR DESCRIPTION
## Summary
- Facilitation guides for the Part II narrative chapters: Creation to Abraham, Moses and the Law, The Prophets, Jesus (Life), Jesus (Death and Resurrection), The Early Church
- Each follows the established template: chapter summary, 3 discussion questions from the text, 2 "Going Deeper" prompts, facilitator notes
- Extends study group runway from 6 weeks to 12 — the full first half
- Week 12 guide includes a midpoint checkpoint prompt (check format/pacing with the group)

## Files
- `study-group/week-07-creation-to-abraham.md`
- `study-group/week-08-moses-and-the-law.md`
- `study-group/week-09-the-prophets.md`
- `study-group/week-10-jesus-the-life.md`
- `study-group/week-11-jesus-death-resurrection.md`
- `study-group/week-12-the-early-church.md`

## Notes for review
- Part II chapters are narrative rather than conceptual — guides lean into story-driven questions
- Week 11 (Death and Resurrection) flags the substitutionary atonement challenge again, noting it hits differently in the narrative context vs. Week 4's theological framing
- Week 12 marks the midpoint — facilitator notes suggest a meta-conversation about how the group is working

🤖 Generated with [Claude Code](https://claude.com/claude-code)