### PR TITLE
Strip em-dashes from outreach templates

### DIFF
--- a/study-group/invitation-variants.md
+++ b/study-group/invitation-variants.md
@@ -1,6 +1,6 @@
 # Personalized Invitation Variants
 
-The [pitch](pitch.md) is the general-purpose version. These variants adjust tone and emphasis for different audiences. Each is designed for personal text, email, or DM — not mass distribution.
+The [pitch](pitch.md) is the general-purpose version. These variants adjust tone and emphasis for different audiences. Each is designed for personal text, email, or DM. Not mass distribution.
 
 All variants link to the same resources:
 - Free online: [christianity.trusthumankind.org](https://christianity.trusthumankind.org)
@@ -14,9 +14,9 @@ All variants link to the same resources:
 
 > Hey [Name] —
 >
-> I wrote a book about Christianity. Fair warning: it's not comfortable. It challenges a lot of what we grew up hearing — substitutionary atonement, the Spirit as a personal guidance system, the idea that salvation is an individual transaction. I think the mission got buried under centuries of institutional scaffolding, and the book tries to dig it back out.
+> I wrote a book about Christianity. Fair warning: it's not comfortable. It challenges a lot of what we grew up hearing: substitutionary atonement, the Spirit as a personal guidance system, the idea that salvation is an individual transaction. I think the mission got buried under centuries of institutional scaffolding, and the book tries to dig it back out.
 >
-> I'm starting a study group — one chapter a week for 24 weeks, starting July 6. Small group, maybe a dozen people. We meet on Discord for weekly discussion threads and one live conversation.
+> I'm starting a study group. One chapter a week for 24 weeks, starting July 6. Small group, maybe a dozen people. We meet on Discord for weekly discussion threads and one live conversation.
 >
 > I want people in this group who will push back. You know the tradition well enough to challenge me where I'm wrong. That's exactly what I need.
 >
@@ -32,9 +32,9 @@ All variants link to the same resources:
 >
 > I know you're not religious, and that's exactly why I'm reaching out.
 >
-> I wrote a book called *Christianity in 24 Hours*. It's not what you'd expect — it argues that most of what people associate with Christianity (the politics, the judgment, the prosperity gospel) is a distortion of the actual message. The real mission is simpler and harder: reducing violence, ending poverty, fighting injustice, and building a world that's fair and equitable for everyone. You and I already share that goal — we just come at it from different starting points.
+> I wrote a book called *Christianity in 24 Hours*. It's not what you'd expect. It argues that most of what people associate with Christianity (the politics, the judgment, the prosperity gospel) is a distortion of the actual message. The real mission is simpler and harder: reducing violence, ending poverty, fighting injustice, and building a world that's fair and equitable for everyone. You and I already share that goal. We just come at it from different starting points.
 >
-> I'm starting a study group — one chapter a week for 24 weeks, starting July 6. You don't need to be a Christian. You don't need to believe anything. The group exists to test the book's arguments honestly, and skepticism is more useful than agreement.
+> I'm starting a study group. One chapter a week for 24 weeks, starting July 6. You don't need to be a Christian. You don't need to believe anything. The group exists to test the book's arguments honestly, and skepticism is more useful than agreement.
 >
 > The full text is free at christianity.trusthumankind.org. If you're curious, let me know.
 >
@@ -46,9 +46,9 @@ All variants link to the same resources:
 
 > Hey [Name] —
 >
-> I finished a book I've been working on for a while — *Christianity in 24 Hours*. Twenty-four chapters covering God, Scripture, sin, salvation, the church's history, and where the mission goes from here. It's a theological argument, not devotional reading. The book takes positions and defends them, and some of them (morality is objective, the Spirit isn't actively guiding individuals today, salvation is communal or it's nothing) will probably start arguments.
+> I finished a book I've been working on for a while: *Christianity in 24 Hours*. Twenty-four chapters covering God, Scripture, sin, salvation, the church's history, and where the mission goes from here. It's a theological argument, not devotional reading. The book takes positions and defends them, and some of them (morality is objective, the Spirit isn't actively guiding individuals today, salvation is communal or it's nothing) will probably start arguments.
 >
-> I'm putting together a study group — one chapter per week, 24 weeks, starting July 6. Small group on Discord. The format is async written discussion plus one live conversation per week. I want people who engage with ideas seriously, whether or not they agree with the conclusions.
+> I'm putting together a study group. One chapter per week, 24 weeks, starting July 6. Small group on Discord. The format is async written discussion plus one live conversation per week. I want people who engage with ideas seriously, whether or not they agree with the conclusions.
 >
 > The text is free at christianity.trusthumankind.org. Let me know if this is your kind of thing.
 >
@@ -60,9 +60,9 @@ All variants link to the same resources:
 
 > Hey [Name] —
 >
-> You know I've been writing this book about faith. It's done — *Christianity in 24 Hours*. I'm proud of it, and I'd love for you to read it, but more than that, I'd love to talk about it with you.
+> You know I've been writing this book about faith. It's done: *Christianity in 24 Hours*. I'm proud of it, and I'd love for you to read it, but more than that, I'd love to talk about it with you.
 >
-> I'm starting a study group — one chapter a week for 24 weeks, starting July 6. Small group, about a dozen people. We meet on Discord (I'll help you set it up if you need). Each week there's a discussion thread and one live conversation.
+> I'm starting a study group. One chapter a week for 24 weeks, starting July 6. Small group, about a dozen people. We meet on Discord (I'll help you set it up if you need). Each week there's a discussion thread and one live conversation.
 >
 > This isn't me preaching. The book takes strong positions and the group exists to challenge them. I want your honest reaction, not your politeness.
 >

--- a/study-group/pitch.md
+++ b/study-group/pitch.md
@@ -2,17 +2,17 @@
 
 Hey —
 
-I wrote a book about faith. Not the comfortable kind — the kind that looks at what Christianity actually says when you strip away the institutional scaffolding, the political baggage, and the "God has a plan" platitudes.
+I wrote a book about faith. Not the comfortable kind. It looks at what Christianity actually says when you strip away the institutional scaffolding, the political baggage, and the "God has a plan" platitudes.
 
 It's called *Christianity in 24 Hours*. Twenty-four chapters, each readable in under an hour. It covers everything: who God is, what the Bible actually says, why the church got so much wrong, and what it would take to get the mission back on track.
 
 The full text is free online at [christianity.trusthumankind.org](https://christianity.trusthumankind.org). If you prefer a physical copy, the paperback is $4.99 on Amazon.
 
-**I'm starting a study group** — one chapter per week, twenty-four weeks. Small group, around a dozen people. We'll meet on Discord at [thechurch.one](https://thechurch.one) for weekly async threads, with one live discussion.
+**I'm starting a study group.** One chapter per week, twenty-four weeks. Small group, around a dozen people. We'll meet on Discord at [thechurch.one](https://thechurch.one) for weekly async threads, with one live discussion.
 
-This isn't a Bible study in the traditional sense. No one is going to tell you what to believe. The book takes positions — strong ones — and the study group is where we test them together. Bring your doubt. Bring your pushback. The whole point is honest engagement, not agreement.
+This isn't a Bible study in the traditional sense. No one is going to tell you what to believe. The book takes strong positions, and the study group is where we test them together. Bring your doubt. Bring your pushback. The whole point is honest engagement, not agreement.
 
-**Starting July 6, 2026.** If you're interested — or even just curious — let me know.
+**Starting July 6, 2026.** If you're interested, or even just curious, let me know.
 
 You don't need to be a Christian. You don't need to be anything. You just need to be willing to read one chapter a week and show up honestly.
 
@@ -20,4 +20,4 @@ You don't need to be a Christian. You don't need to be anything. You just need t
 
 ---
 
-*Personalize as needed. This is designed for personal invitations — adjust the tone for each person.*
+*Personalize as needed. This is designed for personal invitations. Adjust the tone for each person.*


### PR DESCRIPTION
## Summary
- Replaced em-dashes with periods, colons, and commas in pitch.md and invitation-variants.md
- Em-dashes are a known AI writing tell — Marty noticed this while adapting templates for real outreach
- Signature lines ("— Marty") kept as standard convention

## Test plan
- [ ] Read each variant aloud to confirm natural flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)