### PR TITLE
Hour 21: Reduce em-dashes from 36 to 9

### DIFF
--- a/manuscript/ch21-christianity-and-the-world.md
+++ b/manuscript/ch21-christianity-and-the-world.md
@@ -41,7 +41,7 @@ Jesus rejected worldly power as a satanic temptation. The church accepted it as 
 
 ## Colonialism and forced conversion
 
-European colonial expansion from the 15th through the 20th centuries was consistently justified by Christianity. The Doctrine of Discovery, a series of papal decrees, gave Christian nations the right to claim lands inhabited by non-Christians. Indigenous peoples across the Americas, Africa, Asia, and the Pacific were subjected to forced conversion, cultural destruction, and genocide, often with missionaries and soldiers working side by side.
+European colonial expansion from the 15th through the 20th centuries was consistently justified by Christianity. A series of papal decrees together formed the Doctrine of Discovery, which gave Christian nations the right to claim lands inhabited by non-Christians. Indigenous peoples across the Americas, Africa, Asia, and the Pacific were subjected to forced conversion, cultural destruction, and genocide, often with missionaries and soldiers working side by side.
 
 The residential school systems in North America and Australia forcibly removed Indigenous children from their families to "civilize" them in Christian institutions. Languages were forbidden. Cultures were erased. Physical and sexual abuse was rampant. This happened not despite Christianity but in its name.
 
@@ -55,7 +55,7 @@ The abolition movement was also Christian. William Wilberforce, Harriet Beecher 
 
 This matters: the Bible was not the problem. The problem was people reading it to confirm what they already wanted to believe. Slaveholders didn't discover slavery in the Bible; they found verses they could twist to bless what they'd already decided to do. The abolitionists read the same text and found a God who liberated slaves from Egypt, a Jesus who came to set captives free, and a mission built on the dignity of every human being.
 
-The Bible is a mirror. It reflects what you bring to it. That's why reading it honestly, with critical thinking, historical context, and intellectual humility, is not optional.
+The Bible is a mirror. It reflects what you bring to it. That's why reading it honestly, with critical thinking, historical context, and intellectual humility, is a must.
 
 ## The pattern
 
@@ -91,12 +91,12 @@ The answer depends on what you mean by Christianity. If you mean the institution
 
 If you mean the mission — love God, love your neighbor, overcome your fears and vices — then yes. The mission is not invalidated by the institution's failures. It is, in fact, vindicated by them. Every institutional corruption proves exactly what the mission claims: that humans left to their own instincts will choose power over love, self-preservation over sacrifice, comfort over justice. The mission exists because that tendency exists. The failures of the church are evidence for the problem the mission was designed to address.
 
-The question is whether you can separate the signal from the noise. Whether you can hold the mission without inheriting the institution's worst impulses. That's what the remaining hours are about.
+The question is whether you can separate the signal from the noise. Can you hold the mission without inheriting the institution's worst impulses? That's what the remaining hours are about.
 
 ## Questions to sit with
 
 * What has been done in the name of your faith that you find indefensible? Have you reckoned with it honestly, or have you minimized it?
-* Can you distinguish between the mission Jesus described and the institution that claims his name? Where does the institution you belong to, if you belong to one, fall short?
+* Can you distinguish between the mission Jesus described and the institution that claims his name? If you belong to an institution, where does it fall short?
 * If Christianity's track record in the world is mixed at best, what would it look like for you to carry the mission without repeating the pattern?
 
 [1]: https://www.esv.org/John+18/

--- a/manuscript/ch21-christianity-and-the-world.md
+++ b/manuscript/ch21-christianity-and-the-world.md
@@ -2,33 +2,33 @@
 
 Q: If the mission is so clear, why has the church gotten it so wrong?
 
-A: Because the institution was captured by empire seventeen centuries ago — and the church never recovered.
+A: Because the institution was captured by empire seventeen centuries ago. The church never recovered.
 
 ## Commentary
 
 Christianity has been used to justify slavery, launch wars, burn people alive, colonize continents, silence science, oppress women, persecute minorities, and accumulate political power in ways that would have horrified the man it's named after.
 
-That sentence is not anti-Christian. It's history. And if the faith is going to survive honest examination, it has to reckon with what was done in its name — not defensively, not apologetically, but directly.
+That sentence is not anti-Christian. It's history. And if the faith is going to survive honest examination, it has to reckon with what was done in its name. Not defensively. Not apologetically. Directly.
 
 The mission from Hour 1 was clear: overcome our fears and vices to sustainably manage the earth. Love God, love your neighbor. The two commandments. Simple, demanding, and radical.
 
-What happened instead was an institution. And the institution did what institutions do — it accumulated power, protected itself, and called its self-interest God's will.
+What happened instead was an institution. And the institution did what institutions do: it accumulated power, protected itself, and called its self-interest God's will.
 
 ## Constantine and the co-option
 
-For three hundred years after Jesus, Christianity was illegal. Believers met in homes, catacombs, and borrowed spaces. They were hunted, tortured, and killed. The movement grew anyway — not through conquest but through the quality of its community. People noticed that Christians took care of each other, buried the dead of strangers, and stayed in plague-stricken cities when everyone else fled.
+For three hundred years after Jesus, Christianity was illegal. Believers met in homes, catacombs, and borrowed spaces. They were hunted, tortured, and killed. The movement grew anyway. Not through conquest, but through the quality of its community. People noticed that Christians took care of each other, buried the dead of strangers, and stayed in plague-stricken cities when everyone else fled.
 
 Then Emperor Constantine legalized Christianity in 313 AD and eventually made it the empire's favored religion. Overnight, the faith went from persecuted minority to imperial power. Bishops became political figures. Church councils became government events. The theology of a carpenter who owned nothing became the ideology of an empire built on conquest.
 
 This was not a triumph. It was a co-option.
 
-When the empire adopted Christianity, Christianity absorbed the empire's values — hierarchy, territorial control, orthodoxy enforced by law, heresy as a political crime. The faith that Jesus described — a kingdom "not of this world" ([John 18:36][1]) — became very much of this world. It had buildings, budgets, armies, and borders.
+When the empire adopted Christianity, Christianity absorbed the empire's values: hierarchy, territorial control, orthodoxy enforced by law, heresy as a political crime. The faith that Jesus described, a kingdom "not of this world" ([John 18:36][1]), became very much of this world. It had buildings, budgets, armies, and borders.
 
 The early church that shared everything and ensured no one was in need became an institution that owned land, collected taxes, and crowned kings. The prophetic tradition that spoke truth to power became the power that silenced dissent.
 
 ## The Crusades
 
-Between 1096 and 1291, European Christians launched military campaigns to recapture the Holy Land from Muslim control. Hundreds of thousands died — soldiers, civilians, Jews massacred along the way, Muslims and Eastern Christians killed in the siege of Jerusalem. Pope Urban II promised participants remission of sins, turning warfare into a spiritual transaction.
+Between 1096 and 1291, European Christians launched military campaigns to recapture the Holy Land from Muslim control. Hundreds of thousands died: soldiers, civilians, Jews massacred along the way, Muslims and Eastern Christians killed in the siege of Jerusalem. Pope Urban II promised participants remission of sins, turning warfare into a spiritual transaction.
 
 The Crusades were not an aberration. They were the logical result of a faith fused with political power. When the church has an army, the army will be used. When salvation can be earned through military service, violence becomes a sacrament.
 
@@ -41,7 +41,7 @@ Jesus rejected worldly power as a satanic temptation. The church accepted it as 
 
 ## Colonialism and forced conversion
 
-European colonial expansion from the 15th through the 20th centuries was consistently justified by Christianity. The Doctrine of Discovery — a series of papal decrees — gave Christian nations the right to claim lands inhabited by non-Christians. Indigenous peoples across the Americas, Africa, Asia, and the Pacific were subjected to forced conversion, cultural destruction, and genocide, often with missionaries and soldiers working side by side.
+European colonial expansion from the 15th through the 20th centuries was consistently justified by Christianity. The Doctrine of Discovery, a series of papal decrees, gave Christian nations the right to claim lands inhabited by non-Christians. Indigenous peoples across the Americas, Africa, Asia, and the Pacific were subjected to forced conversion, cultural destruction, and genocide, often with missionaries and soldiers working side by side.
 
 The residential school systems in North America and Australia forcibly removed Indigenous children from their families to "civilize" them in Christian institutions. Languages were forbidden. Cultures were erased. Physical and sexual abuse was rampant. This happened not despite Christianity but in its name.
 
@@ -49,13 +49,13 @@ The mission Jesus described in Luke 4:18 — "to proclaim good news to the poor.
 
 ## Slavery
 
-American slavery was explicitly defended from Christian pulpits. Slaveholders cited passages like Ephesians 6:5 ("Bondservants, obey your earthly masters") and the curse of Ham (Genesis 9:25) to argue that God endorsed the enslavement of Black people. Churches split over the issue — the Southern Baptist Convention was founded in 1845 specifically to defend slavery.
+American slavery was explicitly defended from Christian pulpits. Slaveholders cited passages like Ephesians 6:5 ("Bondservants, obey your earthly masters") and the curse of Ham (Genesis 9:25) to argue that God endorsed the enslavement of Black people. Churches split over the issue. The Southern Baptist Convention was founded in 1845 specifically to defend slavery.
 
-The abolition movement was also Christian. William Wilberforce, Harriet Beecher Stowe, Frederick Douglass, Sojourner Truth — all rooted their opposition to slavery in their faith. The same Bible that was used to justify slavery was used to dismantle it.
+The abolition movement was also Christian. William Wilberforce, Harriet Beecher Stowe, Frederick Douglass, Sojourner Truth. All rooted their opposition to slavery in their faith. The same Bible that was used to justify slavery was used to dismantle it.
 
-This matters: the Bible was not the problem. The problem was people reading it to confirm what they already wanted to believe. Slaveholders didn't discover slavery in the Bible — they found verses they could twist to bless what they'd already decided to do. The abolitionists read the same text and found a God who liberated slaves from Egypt, a Jesus who came to set captives free, and a mission built on the dignity of every human being.
+This matters: the Bible was not the problem. The problem was people reading it to confirm what they already wanted to believe. Slaveholders didn't discover slavery in the Bible; they found verses they could twist to bless what they'd already decided to do. The abolitionists read the same text and found a God who liberated slaves from Egypt, a Jesus who came to set captives free, and a mission built on the dignity of every human being.
 
-The Bible is a mirror. It reflects what you bring to it. That's why reading it honestly — with critical thinking, historical context, and intellectual humility — is not optional.
+The Bible is a mirror. It reflects what you bring to it. That's why reading it honestly, with critical thinking, historical context, and intellectual humility, is not optional.
 
 ## The pattern
 
@@ -68,11 +68,11 @@ Jesus anticipated this:
 > "Beware of false prophets, who come to you in sheep's clothing but inwardly are ravenous wolves. You will recognize them by their fruits."
 — [Matthew 7:15-16 ESV][3]
 
-The fruits of Christianity-as-institution include cathedrals, charitable hospitals, universities, abolitionism, civil rights, and countless individual acts of genuine love. They also include crusades, inquisitions, forced assimilation, slavery, and the ongoing entanglement of faith with political power. The question is not whether Christianity has done good — it obviously has. The question is whether the institution is the same thing as the mission. It isn't.
+The fruits of Christianity-as-institution include cathedrals, charitable hospitals, universities, abolitionism, civil rights, and countless individual acts of genuine love. They also include crusades, inquisitions, forced assimilation, slavery, and the ongoing entanglement of faith with political power. The question is not whether Christianity has done good. It obviously has. The question is whether the institution is the same thing as the mission. It isn't.
 
 ## Christianity and politics today
 
-The pattern continues. In the United States and elsewhere, Christianity is routinely deployed as a political identity — used to justify policies on immigration, poverty, sexuality, education, and governance that have little to do with loving God and loving your neighbor.
+The pattern continues. In the United States and elsewhere, Christianity is routinely deployed as a political identity, used to justify policies on immigration, poverty, sexuality, education, and governance that have little to do with loving God and loving your neighbor.
 
 When a politician invokes God to defend a border policy that separates families, that's not the mission. When a church endorses a candidate, that's not the mission. When faith becomes a voter bloc rather than a way of life, the co-option that started with Constantine is alive and well.
 
@@ -81,7 +81,7 @@ When a politician invokes God to defend a border policy that separates families,
 
 Jesus drew a line between political power and the kingdom of God. Every time Christians erase that line — every time they try to legislate the mission rather than live it — they repeat the mistake the faith has been making for seventeen centuries.
 
-The mission doesn't need government support. It doesn't need cultural dominance. It doesn't need a voting majority. It needs people who love their neighbors — including the neighbors who disagree with them, vote against them, and live in ways they find uncomfortable.
+The mission doesn't need government support. It doesn't need cultural dominance. It doesn't need a voting majority. It needs people who love their neighbors, including the neighbors who disagree with them, vote against them, and live in ways they find uncomfortable.
 
 ## What gets carried forward
 
@@ -91,12 +91,12 @@ The answer depends on what you mean by Christianity. If you mean the institution
 
 If you mean the mission — love God, love your neighbor, overcome your fears and vices — then yes. The mission is not invalidated by the institution's failures. It is, in fact, vindicated by them. Every institutional corruption proves exactly what the mission claims: that humans left to their own instincts will choose power over love, self-preservation over sacrifice, comfort over justice. The mission exists because that tendency exists. The failures of the church are evidence for the problem the mission was designed to address.
 
-The question is whether you can separate the signal from the noise — whether you can hold the mission without inheriting the institution's worst impulses. That's what the remaining hours are about.
+The question is whether you can separate the signal from the noise. Whether you can hold the mission without inheriting the institution's worst impulses. That's what the remaining hours are about.
 
 ## Questions to sit with
 
 * What has been done in the name of your faith that you find indefensible? Have you reckoned with it honestly, or have you minimized it?
-* Can you distinguish between the mission Jesus described and the institution that claims his name? Where does the institution you belong to — if you belong to one — fall short?
+* Can you distinguish between the mission Jesus described and the institution that claims his name? Where does the institution you belong to, if you belong to one, fall short?
 * If Christianity's track record in the world is mixed at best, what would it look like for you to carry the mission without repeating the pattern?
 
 [1]: https://www.esv.org/John+18/


### PR DESCRIPTION
## Summary
- Replaced 27 em-dashes with periods, colons, commas, and semicolons throughout Hour 21 (Christianity and the World)
- Kept 9 where the em-dash is genuinely the strongest choice:
  - 3 citation attributions (standard blockquote format)
  - 3 paired parentheticals in the institution-vs-mission contrast paragraphs
  - 1 Sermon on the Mount litany ("love your enemies, turn the other cheek, blessed are the peacemakers")
  - 1 Luke 4:18 dramatic inversion
  - 1 emphatic restatement ("every time they legislate the mission rather than live it")

Continues the pattern from PR #128 (Hour 20). Expecting review comments — this is collaborative editing.

## Test plan
- [ ] Read through for natural flow after replacements
- [ ] Verify no meaning changed, only punctuation

🤖 Generated with [Claude Code](https://claude.com/claude-code)