### PR TITLE
Shorten Hour 11 title to Death and Resurrection

### DIFF
--- a/manuscript/ch10-jesus-the-life.md
+++ b/manuscript/ch10-jesus-the-life.md
@@ -140,4 +140,4 @@ That cost is the next chapter.
 
 ---
 
-[← Hour 9: The Prophets](ch09-the-prophets.html) · [Table of Contents](../) · [Hour 11: Jesus — Death and Resurrection →](ch11-jesus-death-resurrection.html)
+[← Hour 9: The Prophets](ch09-the-prophets.html) · [Table of Contents](../) · [Hour 11: Death and Resurrection →](ch11-jesus-death-resurrection.html)

--- a/manuscript/ch11-jesus-death-resurrection.md
+++ b/manuscript/ch11-jesus-death-resurrection.md
@@ -1,4 +1,4 @@
-# Hour 11: Jesus — Death and Resurrection
+# Hour 11: Death and Resurrection
 
 Q: Why did Jesus have to die?
 

--- a/manuscript/ch12-the-early-church.md
+++ b/manuscript/ch12-the-early-church.md
@@ -134,4 +134,4 @@ The story has been told. The direction is set. All that's needed are people will
 
 ---
 
-[← Hour 11: Jesus — Death and Resurrection](ch11-jesus-death-resurrection.html) · [Table of Contents](../) · [Part III: The Life →](part3.html)
+[← Hour 11: Death and Resurrection](ch11-jesus-death-resurrection.html) · [Table of Contents](../) · [Part III: The Life →](part3.html)

--- a/manuscript/part2.md
+++ b/manuscript/part2.md
@@ -4,7 +4,7 @@
 - Hour 8: [Moses and the Law](ch08-moses-and-the-law.html)
 - Hour 9: [The Prophets](ch09-the-prophets.html)
 - Hour 10: [Jesus: The Life](ch10-jesus-the-life.html)
-- Hour 11: [Jesus: Death and Resurrection](ch11-jesus-death-resurrection.html)
+- Hour 11: [Death and Resurrection](ch11-jesus-death-resurrection.html)
 - Hour 12: [The Early Church](ch12-the-early-church.html)
 
 ---

--- a/manuscript/toc.md
+++ b/manuscript/toc.md
@@ -19,7 +19,7 @@ Preface
 - Hour 8: Moses and the Law
 - Hour 9: The Prophets
 - Hour 10: Jesus — The Life
-- Hour 11: Jesus — Death and Resurrection
+- Hour 11: Death and Resurrection
 - Hour 12: The Early Church
 
 **Part III — The Life**


### PR DESCRIPTION
## Summary
- Drops "Jesus —" prefix from Hour 11 title so it fits on one line in print
- Updates all 5 cross-references (ch10 nav, ch12 nav, part2 listing, toc)

## Test plan
- [ ] Verify TOC entry in print PDF fits on one line
- [ ] Verify chapter heading in print PDF fits on one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)