### PR TITLE
Simplify Hour 10 and Hour 23 titles

### DIFF
--- a/manuscript/ch09-the-prophets.md
+++ b/manuscript/ch09-the-prophets.md
@@ -136,4 +136,4 @@ The Old Testament ends in waiting. The prophets have spoken. The silence has beg
 
 ---
 
-[← Hour 8: Moses and the Law](ch08-moses-and-the-law.html) · [Table of Contents](../) · [Hour 10: Jesus — The Life →](ch10-jesus-the-life.html)
+[← Hour 8: Moses and the Law](ch08-moses-and-the-law.html) · [Table of Contents](../) · [Hour 10: Jesus →](ch10-jesus-the-life.html)

--- a/manuscript/ch10-jesus-the-life.md
+++ b/manuscript/ch10-jesus-the-life.md
@@ -1,4 +1,4 @@
-# Hour 10: Jesus — The Life
+# Hour 10: Jesus
 
 Q: Who was Jesus?
 

--- a/manuscript/ch11-jesus-death-resurrection.md
+++ b/manuscript/ch11-jesus-death-resurrection.md
@@ -158,4 +158,4 @@ That handoff — from the one who proved it possible to the many who would try t
 
 ---
 
-[← Hour 10: Jesus — The Life](ch10-jesus-the-life.html) · [Table of Contents](../) · [Hour 12: The Early Church →](ch12-the-early-church.html)
+[← Hour 10: Jesus](ch10-jesus-the-life.html) · [Table of Contents](../) · [Hour 12: The Early Church →](ch12-the-early-church.html)

--- a/manuscript/ch22-reading-the-bible.md
+++ b/manuscript/ch22-reading-the-bible.md
@@ -93,4 +93,4 @@ When a passage doesn't make sense, set it aside and keep reading. The mission �
 
 ---
 
-[← Hour 21: Christianity and the World](ch21-christianity-and-the-world.html) · [Table of Contents](../) · [Hour 23: Death and What Comes After →](ch23-death-and-afterlife.html)
+[← Hour 21: Christianity and the World](ch21-christianity-and-the-world.html) · [Table of Contents](../) · [Hour 23: What Comes After →](ch23-death-and-afterlife.html)

--- a/manuscript/ch23-death-and-afterlife.md
+++ b/manuscript/ch23-death-and-afterlife.md
@@ -1,4 +1,4 @@
-# Hour 23: Death and What Comes After
+# Hour 23: What Comes After
 
 Q: What happens when we die?
 

--- a/manuscript/ch24-the-decision.md
+++ b/manuscript/ch24-the-decision.md
@@ -137,4 +137,4 @@ Choose life. Today. And tomorrow. And the day after that.
 
 ---
 
-[← Hour 23: Death and What Comes After](ch23-death-and-afterlife.html) · [Table of Contents](../) · [Epilogue: Now Go →](epilogue.html)
+[← Hour 23: What Comes After](ch23-death-and-afterlife.html) · [Table of Contents](../) · [Epilogue: Now Go →](epilogue.html)

--- a/manuscript/part2.md
+++ b/manuscript/part2.md
@@ -3,7 +3,7 @@
 - Hour 7: [Creation to Abraham](ch07-creation-to-abraham.html)
 - Hour 8: [Moses and the Law](ch08-moses-and-the-law.html)
 - Hour 9: [The Prophets](ch09-the-prophets.html)
-- Hour 10: [Jesus: The Life](ch10-jesus-the-life.html)
+- Hour 10: [Jesus](ch10-jesus-the-life.html)
 - Hour 11: [Death and Resurrection](ch11-jesus-death-resurrection.html)
 - Hour 12: [The Early Church](ch12-the-early-church.html)
 

--- a/manuscript/part4.md
+++ b/manuscript/part4.md
@@ -4,7 +4,7 @@
 - Hour 20: [Hard Questions](ch20-hard-questions.html)
 - Hour 21: [Christianity and the World](ch21-christianity-and-the-world.html)
 - Hour 22: [Reading the Bible](ch22-reading-the-bible.html)
-- Hour 23: [Death and What Comes After](ch23-death-and-afterlife.html)
+- Hour 23: [What Comes After](ch23-death-and-afterlife.html)
 - Hour 24: [The Decision](ch24-the-decision.html)
 
 ---

--- a/manuscript/toc.md
+++ b/manuscript/toc.md
@@ -18,7 +18,7 @@ Preface
 - Hour 7: Creation to Abraham
 - Hour 8: Moses and the Law
 - Hour 9: The Prophets
-- Hour 10: Jesus — The Life
+- Hour 10: Jesus
 - Hour 11: Death and Resurrection
 - Hour 12: The Early Church
 
@@ -37,7 +37,7 @@ Preface
 - Hour 20: Hard Questions
 - Hour 21: Christianity and the World
 - Hour 22: Reading the Bible
-- Hour 23: Death and What Comes After
+- Hour 23: What Comes After
 - Hour 24: The Decision
 
 Epilogue: Now Go


### PR DESCRIPTION
## Summary
- Hour 10: "Jesus — The Life" → "Jesus" — avoids repeating Part III's subtitle "The Life"
- Hour 23: "Death and What Comes After" → "What Comes After" — avoids repeating Hour 11's "Death" and prevents line break in print

Both titles updated across all cross-references (nav links, toc.md, part listings). 9 files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)