### PR TITLE
Hour 11: Reduce em-dashes from 43 to 17

### DIFF
--- a/manuscript/ch11-jesus-death-resurrection.md
+++ b/manuscript/ch11-jesus-death-resurrection.md
@@ -119,7 +119,7 @@ The resurrection is the most debated event in human history. Believers and skept
 
 God confirmed the answer.
 
-Jesus carried the mission to the cross. He held where everyone before him had broken. And God's response was to raise him — to say, in the most unmistakable way possible: this is the way. This is what faithfulness looks like. This life, this death, this refusal to choose self even when self-preservation was the only sane option — this is what I was looking for since Genesis 1.
+Jesus carried the mission to the cross. He held where everyone before him had broken. And God's response was to raise him — to say, in the most unmistakable way possible: this is the way. This is what faithfulness looks like. This life, this death, this refusal to choose self even when self-preservation was the only sane option — this is what God was looking for since Genesis 1.
 
 The resurrection is God's verdict on Jesus's life. Not a magic trick. Not a proof of divinity in the traditional sense. A confirmation. The mission can be carried. One person proved it. And because one person proved it, the question shifts from "is it possible?" to "will you?"
 

--- a/manuscript/ch11-jesus-death-resurrection.md
+++ b/manuscript/ch11-jesus-death-resurrection.md
@@ -10,7 +10,7 @@ Hour 10 ended with the cost. Jesus spent three years showing what faithfulness l
 
 This chapter is about what happened next. But before we get there, a framing that matters for everything that follows.
 
-Traditional Christianity teaches that Jesus died as a sacrifice: that God required a payment for humanity's sin, and Jesus was the payment. This is called substitutionary atonement, and it is the dominant framework in most churches. It says: you owed a debt you couldn't pay, Jesus paid it, and now you're free.
+Traditional Christianity teaches that Jesus died as a sacrifice: God required a payment for humanity's sin, and Jesus was the payment. This is called substitutionary atonement, and it is the dominant framework in most churches. It says: you owed a debt you couldn't pay, Jesus paid it, and now you're free.
 
 There is a different take.
 
@@ -20,7 +20,7 @@ Not because the sacrificial language isn't in the Bible. It is. But because with
 
 The final week of Jesus's life is the most detailed period in the Gospels. The writers slowed down here because everything they'd been building toward converges in these days.
 
-Jesus entered Jerusalem on a donkey, not a warhorse. A deliberate statement. The crowds shouted "Hosanna" and laid palm branches on the road. They expected a king. They got a prophet riding the humblest animal available.
+Jesus entered Jerusalem not on a warhorse, but on a donkey — a deliberate statement. The crowds shouted "Hosanna" and laid palm branches on the road. They expected a king. They got a prophet riding the humblest animal available.
 
 He went to the Temple and overturned the tables of the money changers:
 
@@ -50,7 +50,7 @@ After dinner, Jesus went to a garden called Gethsemane. And here is where the ch
 
 He asked God to take the cup from him. He asked three times. He did not want to die.
 
-This is the most important detail in the entire narrative. If Jesus simply accepted his death with divine serenity, if he walked to the cross the way someone walks through a door, it wouldn't mean anything. The test of faithfulness is only real if the alternative is real. Jesus could have walked away. He could have used his gifts to escape. He could have called down those twelve legions of angels. He had every option available to him, including walking away.
+This is the most important detail in the entire narrative. If Jesus simply accepted his death with divine serenity — if he walked to the cross the way someone walks through a door — it wouldn't mean anything. The test of faithfulness is only real if the alternative is real. Jesus could have walked away. He could have used his gifts to escape. He could have called down those twelve legions of angels. He had every option available to him, including walking away.
 
 He chose the mission.
 
@@ -61,7 +61,7 @@ This is Hour 5's definition of faith, taken to its absolute limit. Choosing to a
 
 ## The arrest and trial
 
-Judas betrayed him with a kiss. The disciples ran. Peter, who had sworn he would die before denying Jesus, denied him three times before dawn, exactly as Jesus had predicted.
+Judas betrayed him with a kiss. The disciples ran. Peter, who had sworn he would die before denying Jesus, denied Jesus three times before dawn, exactly as the prophet had predicted.
 
 The trial was a farce. The religious leaders had already decided the outcome. They needed a charge that would stick with the Roman authorities, so they went with sedition, claiming Jesus called himself a king. Pontius Pilate, the Roman governor, found no basis for the charge. He tried to release Jesus.
 
@@ -94,11 +94,11 @@ He died as he lived. Trusting God. Choosing the mission. Holding steadfast where
 
 ## Why this matters
 
-Here is the question the cross forces: if Jesus could have avoided it and chose not to, if this was a choice and not an obligation, what does the cross prove?
+Here is the question the cross forces: if Jesus could have avoided it and chose not to — if this was a choice, not an obligation — then what does the cross prove?
 
 It proves the mission is possible.
 
-Every chapter of Part II has been building a case for why humanity fails. The golden calf. The grumbling in the wilderness. The exile. David and Bathsheba. Four hundred years of prophets warning and being ignored. The evidence for Satan's pessimism, that humanity will always choose self over mission, is overwhelming.
+Every chapter of Part II has been building a case for why humanity fails. The golden calf. The grumbling in the wilderness. The exile. David and Bathsheba. Four hundred years of prophets warning and being ignored. The evidence for Satan's pessimism is overwhelming, that humanity will always choose self over mission.
 
 The cross is our reason for hope.
 
@@ -119,24 +119,24 @@ The resurrection is the most debated event in human history. Believers and skept
 
 God confirmed the answer.
 
-Jesus carried the mission to the cross. He held where everyone before him had broken. And God's response was to raise him, to say, in the most unmistakable way possible: this is the way. This is what faithfulness looks like. This life, this death, this refusal to choose self even when self-preservation was the only sane option — this is what I was looking for since Genesis 1.
+Jesus carried the mission to the cross. He held where everyone before him had broken. And God's response was to raise him — to say, in the most unmistakable way possible: this is the way. This is what faithfulness looks like. This life, this death, this refusal to choose self even when self-preservation was the only sane option — this is what I was looking for since Genesis 1.
 
 The resurrection is God's verdict on Jesus's life. Not a magic trick. Not a proof of divinity in the traditional sense. A confirmation. The mission can be carried. One person proved it. And because one person proved it, the question shifts from "is it possible?" to "will you?"
 
 ## After
 
-Jesus appeared to his disciples over a period of forty days. He ate with them. He let Thomas touch the wounds in his hands. He reinstated Peter, the one who had denied him three times, by asking him the same question three times: "Do you love me?" ([John 21:15-17][10]). No lecture. No demand for explanation. No penance. Just the question, repeated: do you love me? And each time Peter said yes, Jesus gave him work: "Feed my sheep." Three denials met with three chances to say yes, and three commissions to carry the mission forward.
+Jesus appeared to his disciples over a period of forty days. He ate with them. He let Thomas touch the wounds in his hands. He reinstated Peter, the one who had denied him three times, by asking Peter the same question three times: "Do you love me?" ([John 21:15-17][10]). No lecture. No demand for explanation. No penance. Just the question, repeated: do you love me? And each time Peter said yes, Jesus gave him work: "Feed my sheep." Three denials met with three chances to say yes, and three commissions to carry the mission forward.
 
 Then he gave them the mission:
 
 > "Go therefore and make disciples of all nations, baptizing them in the name of the Father and of the Son and of the Holy Spirit, teaching them to observe all that I have commanded you."
 — [Matthew 28:19-20 ESV][11]
 
-The mission that began in a garden, survived a flood, was carried through the wilderness, spoken by the prophets, and embodied by Jesus. That mission was now handed to ordinary people. Fishermen. Tax collectors. People who had run away when it cost them something. People who had denied him.
+The mission that began in a garden, survived a flood, was carried through the wilderness, spoken by the prophets, and embodied by Jesus. That mission was now handed to ordinary people. Fishermen. Tax collectors. People who had run away when it cost them something. People who had denied Jesus.
 
 Not perfect people. Willing people.
 
-That handoff, from the one who proved it possible to the many who would try to live it, is the next chapter.
+The next chapter covers that handoff, from the one who proved it possible to the many who would try to live it.
 
 ## Questions to sit with
 

--- a/manuscript/ch11-jesus-death-resurrection.md
+++ b/manuscript/ch11-jesus-death-resurrection.md
@@ -6,28 +6,28 @@ A: He didn't have to. He chose to. And that choice is the point.
 
 ## Commentary
 
-Hour 10 ended with the cost. Jesus spent three years showing what faithfulness looks like — lived, not legislated. He healed, he taught, he confronted the people who had turned religion into a performance. And the people who ran the performance decided he had to go.
+Hour 10 ended with the cost. Jesus spent three years showing what faithfulness looks like: lived, not legislated. He healed, he taught, he confronted the people who had turned religion into a performance. And the people who ran the performance decided he had to go.
 
 This chapter is about what happened next. But before we get there, a framing that matters for everything that follows.
 
-Traditional Christianity teaches that Jesus died as a sacrifice — that God required a payment for humanity's sin, and Jesus was the payment. This is called substitutionary atonement, and it is the dominant framework in most churches. It says: you owed a debt you couldn't pay, Jesus paid it, and now you're free.
+Traditional Christianity teaches that Jesus died as a sacrifice: that God required a payment for humanity's sin, and Jesus was the payment. This is called substitutionary atonement, and it is the dominant framework in most churches. It says: you owed a debt you couldn't pay, Jesus paid it, and now you're free.
 
 There is a different take.
 
-Not because the sacrificial language isn't in the Bible — it is. But because within the framework built across the last ten hours, the cross means something more specific than a cosmic transaction. Jesus was a prophet with gifts no one else had, who carried the mission without faltering where every prophet before him had broken. His death wasn't a payment. It was the final proof that carrying the mission faithfully is possible, even when the cost is everything.
+Not because the sacrificial language isn't in the Bible. It is. But because within the framework built across the last ten hours, the cross means something more specific than a cosmic transaction. Jesus was a prophet with gifts no one else had, who carried the mission without faltering where every prophet before him had broken. His death wasn't a payment. It was the final proof that carrying the mission faithfully is possible, even when the cost is everything.
 
 ## The last days
 
 The final week of Jesus's life is the most detailed period in the Gospels. The writers slowed down here because everything they'd been building toward converges in these days.
 
-Jesus entered Jerusalem on a donkey, not a warhorse — a deliberate statement. The crowds shouted "Hosanna" and laid palm branches on the road. They expected a king. They got a prophet riding the humblest animal available.
+Jesus entered Jerusalem on a donkey, not a warhorse. A deliberate statement. The crowds shouted "Hosanna" and laid palm branches on the road. They expected a king. They got a prophet riding the humblest animal available.
 
 He went to the Temple and overturned the tables of the money changers:
 
 > And he said to them, "It is written, 'My house shall be called a house of prayer,' but you make it a den of robbers."
 — [Matthew 21:13 ESV][1]
 
-This was not a gentle correction. This was a prophet — in the tradition of Amos and Jeremiah — confronting the institution that had corrupted the mission. The Temple had become a marketplace. The place where people were supposed to encounter God had become a place where people were exploited in God's name.
+This was not a gentle correction. This was a prophet, in the tradition of Amos and Jeremiah, confronting the institution that had corrupted the mission. The Temple had become a marketplace. The place where people were supposed to encounter God had become a place where people were exploited in God's name.
 
 Then the Last Supper. Jesus gathered his disciples, broke bread, and said:
 
@@ -39,7 +39,7 @@ And taking the cup:
 > "This cup that is poured out for you is the new covenant in my blood."
 — [Luke 22:20 ESV][3]
 
-The new covenant. Jeremiah's promise, seven hundred years earlier — the law written on hearts instead of tablets. Jesus is saying: what begins with my death is the transition Jeremiah saw. The old system — Law, Temple, sacrifice — has done its work. What comes next is different.
+The new covenant. Jeremiah's promise, seven hundred years earlier: the law written on hearts instead of tablets. Jesus is saying: what begins with my death is the transition Jeremiah saw. The old system of Law, Temple, and sacrifice has done its work. What comes next is different.
 
 ## Gethsemane
 
@@ -50,7 +50,7 @@ After dinner, Jesus went to a garden called Gethsemane. And here is where the ch
 
 He asked God to take the cup from him. He asked three times. He did not want to die.
 
-This is the most important detail in the entire narrative. If Jesus simply accepted his death with divine serenity — if he walked to the cross the way someone walks through a door — it wouldn't mean anything. The test of faithfulness is only real if the alternative is real. Jesus could have walked away. He could have used his gifts to escape. He could have called down those twelve legions of angels. He had every option available to him, including walking away.
+This is the most important detail in the entire narrative. If Jesus simply accepted his death with divine serenity, if he walked to the cross the way someone walks through a door, it wouldn't mean anything. The test of faithfulness is only real if the alternative is real. Jesus could have walked away. He could have used his gifts to escape. He could have called down those twelve legions of angels. He had every option available to him, including walking away.
 
 He chose the mission.
 
@@ -61,9 +61,9 @@ This is Hour 5's definition of faith, taken to its absolute limit. Choosing to a
 
 ## The arrest and trial
 
-Judas betrayed him with a kiss. The disciples ran. Peter — who had sworn he would die before denying Jesus — denied him three times before dawn, exactly as Jesus had predicted.
+Judas betrayed him with a kiss. The disciples ran. Peter, who had sworn he would die before denying Jesus, denied him three times before dawn, exactly as Jesus had predicted.
 
-The trial was a farce. The religious leaders had already decided the outcome. They needed a charge that would stick with the Roman authorities, so they went with sedition — claiming Jesus called himself a king. Pontius Pilate, the Roman governor, found no basis for the charge. He tried to release Jesus.
+The trial was a farce. The religious leaders had already decided the outcome. They needed a charge that would stick with the Roman authorities, so they went with sedition, claiming Jesus called himself a king. Pontius Pilate, the Roman governor, found no basis for the charge. He tried to release Jesus.
 
 > Pilate said to them, "Then what shall I do with Jesus who is called Christ?" They all said, "Let him be crucified!"
 — [Matthew 27:22 ESV][6]
@@ -74,7 +74,7 @@ The person who had healed their sick, fed their hungry, and told them they matte
 
 Crucifixion was designed to be the worst death the Roman Empire could devise. Nails through the wrists and feet. Suspended by your own body weight. Death by slow asphyxiation as your muscles failed and you could no longer lift yourself to breathe. It could take days.
 
-Jesus was beaten, mocked, stripped, and nailed to a cross between two criminals. A sign was placed above his head: "Jesus of Nazareth, the King of the Jews" — Rome's idea of a joke.
+Jesus was beaten, mocked, stripped, and nailed to a cross between two criminals. A sign was placed above his head: "Jesus of Nazareth, the King of the Jews." It was Rome's idea of a joke.
 
 From the cross, he said seven things. Two of them matter most for the mission.
 
@@ -94,11 +94,11 @@ He died as he lived. Trusting God. Choosing the mission. Holding steadfast where
 
 ## Why this matters
 
-Here is the question the cross forces: if Jesus could have avoided it and chose not to — if this was a choice, not an obligation — then what does the cross prove?
+Here is the question the cross forces: if Jesus could have avoided it and chose not to, if this was a choice and not an obligation, what does the cross prove?
 
 It proves the mission is possible.
 
-Every chapter of Part II has been building a case for why humanity fails. The golden calf. The grumbling in the wilderness. The exile. David and Bathsheba. Four hundred years of prophets warning and being ignored. The evidence for Satan's pessimism — that humanity will always choose self over mission — is overwhelming.
+Every chapter of Part II has been building a case for why humanity fails. The golden calf. The grumbling in the wilderness. The exile. David and Bathsheba. Four hundred years of prophets warning and being ignored. The evidence for Satan's pessimism, that humanity will always choose self over mission, is overwhelming.
 
 The cross is our reason for hope.
 
@@ -119,24 +119,24 @@ The resurrection is the most debated event in human history. Believers and skept
 
 God confirmed the answer.
 
-Jesus carried the mission to the cross. He held where everyone before him had broken. And God's response was to raise him — to say, in the most unmistakable way possible: this is the way. This is what faithfulness looks like. This life, this death, this refusal to choose self even when self-preservation was the only sane option — this is what I was looking for since Genesis 1.
+Jesus carried the mission to the cross. He held where everyone before him had broken. And God's response was to raise him, to say, in the most unmistakable way possible: this is the way. This is what faithfulness looks like. This life, this death, this refusal to choose self even when self-preservation was the only sane option — this is what I was looking for since Genesis 1.
 
 The resurrection is God's verdict on Jesus's life. Not a magic trick. Not a proof of divinity in the traditional sense. A confirmation. The mission can be carried. One person proved it. And because one person proved it, the question shifts from "is it possible?" to "will you?"
 
 ## After
 
-Jesus appeared to his disciples over a period of forty days. He ate with them. He let Thomas touch the wounds in his hands. He reinstated Peter — the one who had denied him three times — by asking him the same question three times: "Do you love me?" ([John 21:15-17][10]). No lecture. No demand for explanation. No penance. Just the question, repeated: do you love me? And each time Peter said yes, Jesus gave him work: "Feed my sheep." Three denials met with three chances to say yes — and three commissions to carry the mission forward.
+Jesus appeared to his disciples over a period of forty days. He ate with them. He let Thomas touch the wounds in his hands. He reinstated Peter, the one who had denied him three times, by asking him the same question three times: "Do you love me?" ([John 21:15-17][10]). No lecture. No demand for explanation. No penance. Just the question, repeated: do you love me? And each time Peter said yes, Jesus gave him work: "Feed my sheep." Three denials met with three chances to say yes, and three commissions to carry the mission forward.
 
 Then he gave them the mission:
 
 > "Go therefore and make disciples of all nations, baptizing them in the name of the Father and of the Son and of the Holy Spirit, teaching them to observe all that I have commanded you."
 — [Matthew 28:19-20 ESV][11]
 
-The mission that began in a garden, survived a flood, was carried through the wilderness, spoken by the prophets, and embodied by Jesus — that mission was now handed to ordinary people. Fishermen. Tax collectors. People who had run away when it cost them something. People who had denied him.
+The mission that began in a garden, survived a flood, was carried through the wilderness, spoken by the prophets, and embodied by Jesus. That mission was now handed to ordinary people. Fishermen. Tax collectors. People who had run away when it cost them something. People who had denied him.
 
 Not perfect people. Willing people.
 
-That handoff — from the one who proved it possible to the many who would try to live it — is the next chapter.
+That handoff, from the one who proved it possible to the many who would try to live it, is the next chapter.
 
 ## Questions to sit with
 


### PR DESCRIPTION
## Summary

Editorial cleanup of em-dashes in the crucifixion/resurrection chapter (Death and Resurrection).

- **43 → 17** total em-dashes (10 citations + 7 content kept)
- 26 replacements using colons, commas, periods, and restructured sentences

## What's kept (7 content em-dashes)

All at the chapter's most dramatic moments:
- **Line 86** (paired): "the mission — love your neighbor — carried to its absolute extreme" — the forgiveness on the cross
- **Line 105** (paired): "the test from Hour 1 — can humanity overcome its fears and vices? — needed at least one person to answer yes" — structural callback
- **Line 109** (paired): "a human being — die for the people who are killing you... drive nails into your hands — one person chose faithfulness" — the climactic litany
- **Line 122**: "the only sane option — this is what I was looking for since Genesis 1" — God's verdict pivot

## Approach

Applied lessons from PR #129 review (4 comments, all editorial). This chapter sustains a slightly higher ratio of kept em-dashes than Hour 21 because it's narrative climax, not analytical prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)