### PR TITLE
Add facilitation guides for Weeks 19-24 (Part IV)

### DIFF
--- a/study-group/week-19-fake-faith.md
+++ b/study-group/week-19-fake-faith.md
@@ -1,0 +1,28 @@
+# Week 19: Hour 19 — Fake Faith
+
+**Read:** [Hour 19: Fake Faith](https://christianity.trusthumankind.org/manuscript/ch19-fake-faith.html)
+
+## This Week's Chapter
+
+Jesus spent more energy fighting fake faith than fighting unbelief. The people who drew his sharpest words were the ones already inside: right theology, right titles, right attendance record, and none of the life to show for it.
+
+The chapter identifies three forms: performance without purpose (the Pharisees, who tithed on spices while neglecting justice), transaction disguised as devotion (the prosperity gospel, where you give in order to get), and cultural Christianity (faith as a label, not a discipline). The common thread: every form of fake faith is easier than the real thing. The test of genuine faith is not theology or attendance. It's whether you've honestly faced every reason to walk away and still chosen to stay.
+
+This is the opening of Part IV. The first eighteen hours built the case and the practice. The final six ask: is what you're carrying real?
+
+## Discussion Questions
+
+1. **Which form of fake faith is closest to your own default: performance, transaction, or cultural Christianity?** Don't pick the one that sounds most self-aware. Pick the one that's honest. Where do you take the shortcut instead of doing the hard thing?
+
+2. **Jesus said "I never knew you" to people who prophesied and did mighty works in his name. What's the difference between doing things for God and actually knowing God?** This is one of the most unsettling passages in the Gospels. If the résumé isn't enough, what is?
+
+3. **If someone watched your life for a week — not your Sunday, your whole week — what would they conclude you actually believe?** Not what you'd tell them. What the evidence shows.
+
+## Going Deeper
+
+- The chapter says the Pharisees substituted behavior for character. They could quote Leviticus but couldn't see the person standing in front of them who needed help. Where in your life is your theological knowledge outpacing your actual practice?
+- Paul argues that clinging to rule-following as the measure of faith means you've stopped growing. Where are you still clinging to a rule when the principle behind it would set you free?
+
+## Facilitator Notes
+
+This chapter can feel like an attack, especially if someone in the group recognizes themselves in one of the three forms. The tone matters: the chapter is not condemning anyone. It's offering a diagnostic. If someone gets defensive, that defensiveness may itself be worth examining, gently. Question 1 works best if the facilitator goes first and is genuinely honest. Model vulnerability here. The chapter's most important line is the test: "Have you reckoned honestly with every reason to walk away and still chosen to stay?" That's the question underneath all three discussion questions. Let the group find their way to it.

--- a/study-group/week-20-hard-questions.md
+++ b/study-group/week-20-hard-questions.md
@@ -1,0 +1,28 @@
+# Week 20: Hour 20 — Hard Questions
+
+**Read:** [Hour 20: Hard Questions](https://christianity.trusthumankind.org/manuscript/ch20-hard-questions.html)
+
+## This Week's Chapter
+
+The chapter takes on the questions that make people leave: other religions, Old Testament violence, hell, science, biblical contradictions, unanswered prayer, marriage, children, and abortion. It doesn't pretend to settle any of them. What it does is model honest engagement: "the Bible doesn't give a one-word answer" is the refrain.
+
+The framework shifts some questions entirely. If God shows no partiality and the mission was given to all humanity, then a Buddhist practicing compassion and a secular humanist building clean water systems may be carrying the same mission with different language. If suffering has no hidden purpose and God stepped back, then unanswered prayer isn't a failure. It's a misunderstanding of what prayer does.
+
+The question behind all the questions: can I trust this? The answer from the previous chapter: real faith means sitting with that question and choosing the mission anyway.
+
+## Discussion Questions
+
+1. **Which of these hard questions is the one you've been avoiding?** Not the one you find intellectually interesting. The one you've been afraid to look at honestly. What would it mean to face it instead of working around it?
+
+2. **The chapter says a Buddhist practicing compassion may be carrying the same mission as a Christian. Does that feel liberating or threatening?** Your reaction reveals something about what you think faith is for. Is it about the label or the mission?
+
+3. **The abortion section argues the problem is not the woman's right to choose but the absence of community that makes the choice feel impossible. Does that reframe the issue for you?** If so, what does the reframe demand of you practically?
+
+## Going Deeper
+
+- The chapter gives three lenses for Old Testament violence: developmental, human authorship, and tension. Which lens do you find most honest? Which feels like a cop-out? What does your preference reveal about how you read the Bible?
+- Paul recommended singleness over marriage for carrying the mission. Jesus never married. The church somehow made marriage the default. What assumptions about your life have you absorbed from church culture that the actual text doesn't support?
+
+## Facilitator Notes
+
+This is the widest-ranging chapter in the book, and the discussion could scatter. Pick one or two questions that resonate most with the group and go deep rather than trying to cover everything. The abortion section will generate the strongest reactions. If it comes up, hold the space carefully: the chapter explicitly rejects both the political left and right framings and asks the group to sit with complexity. The facilitator's role is to protect that complexity, not resolve it. If someone tries to reduce the discussion to a position, redirect: "What does the chapter actually say?" The goal is honest wrestling, not consensus.

--- a/study-group/week-21-christianity-and-the-world.md
+++ b/study-group/week-21-christianity-and-the-world.md
@@ -1,0 +1,26 @@
+# Week 21: Hour 21 — Christianity and the World
+
+**Read:** [Hour 21: Christianity and the World](https://christianity.trusthumankind.org/manuscript/ch21-christianity-and-the-world.html)
+
+## This Week's Chapter
+
+Christianity has been used to justify slavery, launch wars, colonize continents, and accumulate political power in ways that would have horrified the man it's named after. The chapter doesn't flinch from this. It traces the pattern: Constantine co-opted the mission for political control. The Crusaders weaponized it. The colonizers exploited it. The slaveholders twisted it. In each case, the language of the mission was preserved while the substance was gutted.
+
+The chapter's central question: is Christianity still worth carrying? The answer: it depends on whether you mean the institution or the mission. The institution's failures are evidence for exactly the problem the mission was designed to address. Humans left to their own instincts will choose power over love. The mission exists because that tendency exists.
+
+## Discussion Questions
+
+1. **What has been done in the name of your faith that you find indefensible? Have you reckoned with it honestly, or have you minimized it?** This is not about guilt. It's about honesty. You can carry the mission forward without pretending the institution's history is clean.
+
+2. **Can you separate the mission Jesus described from the institution that claims his name?** Where does the institution you belong to — or grew up in — fall short of the mission? Where does it get it right?
+
+3. **The chapter says Jesus rejected worldly power as a satanic temptation. The church accepted it as God's blessing. Where do you see that pattern today?** Name something specific in contemporary Christianity where the mission has been traded for power, comfort, or control.
+
+## Going Deeper
+
+- The abolition movement was also Christian. The same Bible used to justify slavery was used to dismantle it. The chapter calls the Bible "a mirror" that reflects what you bring to it. What are you bringing to your reading? What do you want to confirm, and how might that be shaping what you find?
+- The chapter ends: "Can you hold the mission without inheriting the institution's worst impulses?" What specific impulse from institutional Christianity do you need to consciously reject in order to carry the mission honestly?
+
+## Facilitator Notes
+
+This is one of the most emotionally charged chapters. Some participants may feel defensive about their church or tradition. Others may feel vindicated. Neither reaction is the goal. The goal is honest reckoning. The chapter models this: it names specific failures (Crusades, slavery, colonialism) without condemning faith itself. The facilitator should hold that same tension. If the discussion veers into church-bashing or defensive justification, pull it back to the chapter's structure: what's the pattern, and where do you see it in your own life? Question 3 is where it gets personal. Don't let the group stay in historical abstractions.

--- a/study-group/week-22-reading-the-bible.md
+++ b/study-group/week-22-reading-the-bible.md
@@ -1,0 +1,26 @@
+# Week 22: Hour 22 — Reading the Bible
+
+**Read:** [Hour 22: Reading the Bible](https://christianity.trusthumankind.org/manuscript/ch22-reading-the-bible.html)
+
+## This Week's Chapter
+
+The Bible tells one story across sixty-six books: humanity growing up. Once you see that arc, everything else falls into place. The chapter maps every section of the Bible to that progression — from Genesis (God creates, humanity stumbles) through the Law (parenting on a civilizational scale) through the prophets (truth to power) through Jesus (someone finally lives it) to Revelation (not destruction but restoration).
+
+The single most useful reading lens: every passage is either advancing the mission, showing what happens when the mission is abandoned, or processing the human experience of carrying it. You don't need ancient languages or a seminary degree. You need the mission in mind and the honesty to let the text challenge you.
+
+## Discussion Questions
+
+1. **Have you ever felt intimidated by the Bible — like you needed an expert to understand it?** What would change if you read it as the story of humanity growing up instead of a mystery requiring trained interpreters?
+
+2. **The chapter says the Bible is a mirror: it reflects what you bring to it. What are you bringing to your reading right now?** What do you want the Bible to confirm? What are you hoping it won't say?
+
+3. **Pick a passage that has confused or troubled you. Ask the chapter's question: where in humanity's growth does this belong?** Does that lens clarify it? Share the passage and your reading with the group.
+
+## Going Deeper
+
+- The chapter warns against treating Revelation as a calendar or an end-times prediction. If Revelation is a letter of hope to persecuted Christians rather than a prediction of the future, how does that change what you take from it? What do you lose? What do you gain?
+- The chapter ends: "The story is simple. Living the moral of that story is what's hard." After twenty-two weeks, has the story gotten simpler or more complicated for you? Where is living it hardest?
+
+## Facilitator Notes
+
+This is the most practical chapter in Part IV — it gives people a tool (the mission lens) for reading the Bible on their own. The discussion should produce at least one moment where someone applies the lens to a real passage in real time (Question 3). If no one volunteers, have a passage ready. Suggestions: Judges 11 (Jephthah's vow), Psalm 137:9 (dashing infants against rocks), or Romans 9 (predestination language). The point is not to resolve the passage but to practice the reading method. The chapter's confidence ("you don't need a seminary degree") may feel too simple for some participants. Let that tension surface. The response: the chapter isn't saying scholarship is worthless. It's saying the forest shouldn't be hidden behind the trees.

--- a/study-group/week-23-what-comes-after.md
+++ b/study-group/week-23-what-comes-after.md
@@ -1,0 +1,28 @@
+# Week 23: Hour 23 — What Comes After
+
+**Read:** [Hour 23: What Comes After](https://christianity.trusthumankind.org/manuscript/ch23-death-and-afterlife.html)
+
+## This Week's Chapter
+
+What happens when we die? The honest answer: Christians disagree, and the Bible says less about it than most people think. The Old Testament barely addresses the afterlife. The New Testament uses parables and visions. Jesus's Sheep and Goats parable judges people not by theology but by whether they fed the hungry, clothed the naked, visited the prisoner.
+
+The chapter presents three views of hell — eternal torment, annihilation, and universal restoration — and declares for universal restoration. The argument: a parent who tortures a child forever for failing to grow up is not a parent but a tyrant. "Love me or burn" is not a relationship but a hostage situation. The chapter grounds this in concrete human lives: babies who die in the NICU, soldiers sent to wars they didn't choose, murderers whose victims' families carry wounds forever. What does a loving and just God do with all of them?
+
+The Christian hope is not "going to heaven when you die." It is resurrection — the renewal of all things, God moving in, not away.
+
+## Discussion Questions
+
+1. **Think of someone you consider irredeemable. Now ask: does God agree with you?** What would it change about how you treat that person if restoration were possible even for them?
+
+2. **The chapter says "goat" is a posture you can change, not a category you're born into. Which posture are you choosing today?** Be specific. Where in your life this week are you choosing comfort over love — the goat posture — and where are you choosing the mission?
+
+3. **If the endpoint is restoration rather than escape — God moving into the renewed world, not pulling you out of it — how does that change what you're working toward?** Does the mission feel different if the destination is here, transformed, rather than somewhere else?
+
+## Going Deeper
+
+- The chapter argues that eternal conscious torment makes God a bureaucrat and annihilationism makes God give up. Only universal restoration is consistent with the parable of the lost sheep — leaving the ninety-nine to find the one. Does that argument hold for you? Where does it break?
+- The chapter presents tragic human cases (NICU babies, soldiers, murderers) and asks what a loving God does with each. Which case challenges you most? What does your reaction reveal about your theology?
+
+## Facilitator Notes
+
+This chapter deals with death, judgment, and the afterlife — topics that are deeply personal and often tied to grief. Someone in the group may have lost a loved one whose eternal fate they've worried about. The universal restoration position may be profoundly relieving for them. Others may find it too permissive — "everyone gets in?" — and push back. Both reactions are legitimate. The facilitator's job is to hold space for the theological disagreement without letting it become abstract. The concrete cases (babies, soldiers, murderers) keep it grounded. Question 1 is the most revealing: who we consider irredeemable says as much about us as about them. Let that sit.

--- a/study-group/week-24-the-decision.md
+++ b/study-group/week-24-the-decision.md
@@ -1,0 +1,34 @@
+# Week 24: Hour 24 — The Decision
+
+**Read:** [Hour 24: The Decision](https://christianity.trusthumankind.org/manuscript/ch24-the-decision.html)
+
+## This Week's Chapter
+
+Twenty-three hours later, the question returns and becomes personal: not whether humanity can get this right, but whether you will. The chapter lays out seven markers of spiritual maturity (choose love when it hurts, tell truth to yourself, stay, give until you notice, sit with suffering, forgive, hold doubt) and five concrete victory conditions (one country, one currency, food security, housing security, education without gatekeepers).
+
+The real wager is not Pascal's calculation. It is this: will you give your life to something bigger than yourself, knowing it will cost you? The mission does not promise comfort. It promises peace — the peace of knowing what you stand for. And an endpoint: the debrief with God and with Satan. Why this test? Why the suffering? Full clarity about what it cost and why it was worth it.
+
+Choose life. Today. And tomorrow. And the day after that.
+
+## Discussion Questions
+
+1. **If you measured your spiritual maturity not by what you believe but by how you love — honestly, right now — where are you?** Run yourself against the seven markers. Which ones are you growing in? Which ones are you avoiding?
+
+2. **What would change in your life this week if you took the two commandments seriously — not as theology, but as a daily practice?** Not next month. Not eventually. This week. Name one thing you would do differently starting tomorrow.
+
+3. **The mission asks whether humanity can get this right. Your part of the answer is your life. What is your life saying?** After twenty-four weeks with this book and this group, what has changed? What hasn't? What will you carry forward?
+
+## Going Deeper
+
+- The victory conditions are concrete and measurable: one country, one currency, food and housing for every human being, education without gatekeepers. Do you believe these are achievable? If not, what does that say about your faith in the mission? If yes, what are you doing about it?
+- The chapter describes the reward as "a seat at the table with everyone who ever chose the mission over personal gain." Is that enough for you? If not, what are you actually hoping for?
+
+## Facilitator Notes
+
+This is the final week. It should feel like a culmination, not a lecture. The group has spent twenty-four weeks together. Relationships have formed. The discussion should honor that.
+
+Start by acknowledging the journey. Then let the questions do their work. Question 3 is the capstone — "what is your life saying?" — and it deserves the most time. Don't rush through it.
+
+After the discussion, take time to close the group intentionally. Options: ask each person to name one thing that shifted for them over the twenty-four weeks. Ask what they'll carry forward. Ask if they want to continue meeting in some form. The book ends with "choose life." The group should end with a concrete next step: what does choosing life look like for each person in the room, starting now?
+
+If the group wants to continue, the epilogue (thechurch.one Discord, GoFundMe) provides a path. But the most important outcome is not continued attendance. It is whether anyone in the room treats their neighbor differently tomorrow because of what happened in this group. One person. That's the mission.


### PR DESCRIPTION
## Summary
- Adds 6 facilitation guides covering Part IV: The Decision (Weeks 19-24)
- Chapters covered: Fake Faith, Hard Questions, Christianity and the World, Reading the Bible, What Comes After, The Decision
- Completes the full 24-week facilitation guide set (Weeks 1-12 on main, Weeks 13-18 in PR #151)
- Study group launches Jul 6 — all guides now drafted

## Test plan
- [ ] Review each guide against its corresponding chapter for accuracy
- [ ] Verify discussion questions align with chapter themes and voice
- [ ] Check facilitator notes for practical usefulness
- [ ] Review Week 24 closing guidance for study group wrap-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)