### PR TITLE
Rename book to Christianity Reconstructed in 24 Hours

### DIFF
--- a/OUTLINE.md
+++ b/OUTLINE.md
@@ -1,4 +1,4 @@
-# Christianity in 24 Hours — Outline
+# Christianity Reconstructed in 24 Hours — Outline
 
 This is the working outline for the book. Chapters marked with ✅ have drafts.
 The outline is a living document — expect it to evolve as content comes together

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Christianity in 24 Hours
+# Christianity Reconstructed in 24 Hours
 
 This living book (meaning never finished, always being challenged and refined) is modeled after the [Sams Teach Yourself][1] series, with the belief that Christianity shouldn't require a master's degree to understand.
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: Christianity in 24 Hours
+title: Christianity Reconstructed in 24 Hours
 description: The Bible tells one story. Humanity growing up.
 theme: jekyll-theme-minimal
 plugins:

--- a/assets/covers/full-wrap-draft.svg
+++ b/assets/covers/full-wrap-draft.svg
@@ -58,7 +58,7 @@
 
   <g transform="translate(1634, 1209) rotate(90)">
     <text x="0" y="0" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="50" fill="#ffffff" letter-spacing="4">
-      <tspan font-weight="bold">Christianity in 24 Hours</tspan>
+      <tspan font-weight="bold">Christianity Reconstructed in 24 Hours</tspan>
       <tspan dx="48" fill="#c49a3c">Marty Chang &amp; Coraline Chang</tspan>
     </text>
   </g>
@@ -67,9 +67,11 @@
 
   <text x="2471" y="1617" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="1200" font-weight="bold" fill="#222222">24</text>
 
-  <text x="2471" y="670" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="150" font-weight="bold" fill="#ffffff" letter-spacing="6">Christianity</text>
+  <text x="2471" y="620" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="150" font-weight="bold" fill="#ffffff" letter-spacing="6">Christianity</text>
 
-  <text x="2471" y="790" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="58" fill="#888888" letter-spacing="12" font-style="italic">in</text>
+  <text x="2471" y="720" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="90" font-weight="bold" fill="#c49a3c" letter-spacing="8">Reconstructed</text>
+
+  <text x="2471" y="800" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="58" fill="#888888" letter-spacing="12" font-style="italic">in</text>
 
   <text x="2471" y="980" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="150" font-weight="bold" fill="#c49a3c" letter-spacing="6">24 Hours</text>
 

--- a/assets/covers/full-wrap-draft.svg
+++ b/assets/covers/full-wrap-draft.svg
@@ -67,9 +67,9 @@
 
   <text x="2471" y="1617" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="1200" font-weight="bold" fill="#222222">24</text>
 
-  <text x="2471" y="520" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="150" font-weight="bold" fill="#ffffff" letter-spacing="6">Christianity</text>
+  <text x="2471" y="600" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="150" font-weight="bold" fill="#ffffff" letter-spacing="6">Christianity</text>
 
-  <text x="2471" y="620" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="90" font-weight="bold" fill="#c49a3c" letter-spacing="8">Reconstructed</text>
+  <text x="2471" y="700" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="90" font-weight="bold" fill="#c49a3c" letter-spacing="8">Reconstructed</text>
 
   <text x="2471" y="800" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="58" fill="#888888" letter-spacing="12" font-style="italic">in</text>
 

--- a/assets/covers/full-wrap-draft.svg
+++ b/assets/covers/full-wrap-draft.svg
@@ -67,9 +67,9 @@
 
   <text x="2471" y="1617" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="1200" font-weight="bold" fill="#222222">24</text>
 
-  <text x="2471" y="620" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="150" font-weight="bold" fill="#ffffff" letter-spacing="6">Christianity</text>
+  <text x="2471" y="520" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="150" font-weight="bold" fill="#ffffff" letter-spacing="6">Christianity</text>
 
-  <text x="2471" y="720" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="90" font-weight="bold" fill="#c49a3c" letter-spacing="8">Reconstructed</text>
+  <text x="2471" y="620" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="90" font-weight="bold" fill="#c49a3c" letter-spacing="8">Reconstructed</text>
 
   <text x="2471" y="800" text-anchor="middle" font-family="'Crimson Text', Georgia, serif" font-size="58" fill="#888888" letter-spacing="12" font-style="italic">in</text>
 

--- a/assets/epub-metadata.yaml
+++ b/assets/epub-metadata.yaml
@@ -1,5 +1,5 @@
 ---
-title: Christianity in 24 Hours
+title: Christianity Reconstructed in 24 Hours
 subtitle: One story. One decision.
 author: Marty Chang and Coraline Chang
 lang: en-US

--- a/assets/kdp-metadata.yaml
+++ b/assets/kdp-metadata.yaml
@@ -2,7 +2,7 @@
 # KDP Listing Metadata
 # Prepared for Amazon KDP upload
 
-title: Christianity in 24 Hours
+title: Christianity Reconstructed in 24 Hours
 subtitle: One story. One decision.
 authors:
   - Marty Chang
@@ -17,7 +17,7 @@ description: |
 
   But the mission didn't die. It's been waiting — for a generation with enough clarity to see what went wrong, enough honesty to name it, and enough courage to try again.
 
-  _Christianity in 24 Hours_ strips the faith to its core. In 24 chapters you can read in under a day, this book walks through everything: who God is, what the Bible actually says, what sin and salvation really mean, the full arc of Scripture from Genesis to Revelation, the life Jesus calls people to live, and the decision everyone eventually has to make.
+  _Christianity Reconstructed in 24 Hours_ strips the faith to its core. In 24 chapters you can read in under a day, this book walks through everything: who God is, what the Bible actually says, what sin and salvation really mean, the full arc of Scripture from Genesis to Revelation, the life Jesus calls people to live, and the decision everyone eventually has to make.
 
   This is not apologetics. This is not a devotional. This is a clear-eyed, honest look at what Christianity teaches — written for skeptics, seekers, and believers who suspect they've been sold a version of the faith that doesn't match what Jesus actually said.
   - What if the Bible tells one story — humanity growing up?

--- a/assets/print-template.typ
+++ b/assets/print-template.typ
@@ -1,4 +1,4 @@
-// Christianity in 24 Hours — Print template for pandoc + typst
+// Christianity Reconstructed in 24 Hours — Print template for pandoc + typst
 // Trim: 5.06 x 7.81 in — KDP paperback
 
 #let horizontalrule = line(start: (25%,0%), end: (75%,0%))
@@ -105,7 +105,7 @@
       if n == 1 {
 
         align(center + horizon)[
-          #text(size: 22pt, weight: "bold", fill: black)[Christianity in 24 Hours]
+          #text(size: 22pt, weight: "bold", fill: black)[Christianity Reconstructed in 24 Hours]
           #v(0.5em)
           #text(size: 13pt, style: "italic", fill: black)[One story. One decision.]
           #v(1em)

--- a/index.md
+++ b/index.md
@@ -1,9 +1,9 @@
 ---
 layout: default
-title: Christianity in 24 Hours
+title: Christianity Reconstructed in 24 Hours
 ---
 
-# Christianity in 24 Hours
+# Christianity Reconstructed in 24 Hours
 
 **By Marty Chang and Coraline Chang**
 

--- a/manuscript/copyright.md
+++ b/manuscript/copyright.md
@@ -1,6 +1,6 @@
 # Copyright {.copyright .unnumbered}
 
-Christianity in 24 Hours
+Christianity Reconstructed in 24 Hours
 
 Copyright © 2026 Marty Chang. All rights reserved.
 

--- a/manuscript/halftitle.md
+++ b/manuscript/halftitle.md
@@ -1,1 +1,1 @@
-# Christianity in 24 Hours {.halftitle .unnumbered}
+# Christianity Reconstructed in 24 Hours {.halftitle .unnumbered}

--- a/manuscript/titlepage.md
+++ b/manuscript/titlepage.md
@@ -1,4 +1,4 @@
-# Christianity in 24 Hours {.titlepage .unnumbered}
+# Christianity Reconstructed in 24 Hours {.titlepage .unnumbered}
 
 *One story. One decision.*
 

--- a/study-group/invitation-variants.md
+++ b/study-group/invitation-variants.md
@@ -32,7 +32,7 @@ All variants link to the same resources:
 >
 > I know you're not religious, and that's exactly why I'm reaching out.
 >
-> I wrote a book called *Christianity in 24 Hours*. It's not what you'd expect. It argues that most of what people associate with Christianity (the politics, the judgment, the prosperity gospel) is a distortion of the actual message. The real mission is simpler and harder: reducing violence, ending poverty, fighting injustice, and building a world that's fair and equitable for everyone. You and I already share that goal. We just come at it from different starting points.
+> I wrote a book called *Christianity Reconstructed in 24 Hours*. It's not what you'd expect. It argues that most of what people associate with Christianity (the politics, the judgment, the prosperity gospel) is a distortion of the actual message. The real mission is simpler and harder: reducing violence, ending poverty, fighting injustice, and building a world that's fair and equitable for everyone. You and I already share that goal. We just come at it from different starting points.
 >
 > I'm starting a study group. One chapter a week for 24 weeks, starting July 6. You don't need to be a Christian. You don't need to believe anything. The group exists to test the book's arguments honestly, and skepticism is more useful than agreement.
 >
@@ -46,7 +46,7 @@ All variants link to the same resources:
 
 > Hey [Name] —
 >
-> I finished a book I've been working on for a while: *Christianity in 24 Hours*. Twenty-four chapters covering God, Scripture, sin, salvation, the church's history, and where the mission goes from here. It's a theological argument, not devotional reading. The book takes positions and defends them, and some of them (morality is objective, the Spirit isn't actively guiding individuals today, salvation is communal or it's nothing) will probably start arguments.
+> I finished a book I've been working on for a while: *Christianity Reconstructed in 24 Hours*. Twenty-four chapters covering God, Scripture, sin, salvation, the church's history, and where the mission goes from here. It's a theological argument, not devotional reading. The book takes positions and defends them, and some of them (morality is objective, the Spirit isn't actively guiding individuals today, salvation is communal or it's nothing) will probably start arguments.
 >
 > I'm putting together a study group. One chapter per week, 24 weeks, starting July 6. Small group on Discord. The format is async written discussion plus one live conversation per week. I want people who engage with ideas seriously, whether or not they agree with the conclusions.
 >
@@ -60,7 +60,7 @@ All variants link to the same resources:
 
 > Hey [Name] —
 >
-> You know I've been writing this book about faith. It's done: *Christianity in 24 Hours*. I'm proud of it, and I'd love for you to read it, but more than that, I'd love to talk about it with you.
+> You know I've been writing this book about faith. It's done: *Christianity Reconstructed in 24 Hours*. I'm proud of it, and I'd love for you to read it, but more than that, I'd love to talk about it with you.
 >
 > I'm starting a study group. One chapter a week for 24 weeks, starting July 6. Small group, about a dozen people. We meet on Discord (I'll help you set it up if you need). Each week there's a discussion thread and one live conversation.
 >

--- a/study-group/pitch.md
+++ b/study-group/pitch.md
@@ -1,10 +1,10 @@
-# Christianity in 24 Hours — Study Group Invitation
+# Christianity Reconstructed in 24 Hours — Study Group Invitation
 
 Hey —
 
 I wrote a book about faith. Not the comfortable kind. It looks at what Christianity actually says when you strip away the institutional scaffolding, the political baggage, and the "God has a plan" platitudes.
 
-It's called *Christianity in 24 Hours*. Twenty-four chapters, each readable in under an hour. It covers everything: who God is, what the Bible actually says, why the church got so much wrong, and what it would take to get the mission back on track.
+It's called *Christianity Reconstructed in 24 Hours*. Twenty-four chapters, each readable in under an hour. It covers everything: who God is, what the Bible actually says, why the church got so much wrong, and what it would take to get the mission back on track.
 
 The full text is free online at [christianity.trusthumankind.org](https://christianity.trusthumankind.org). If you prefer a physical copy, the paperback is $4.99 on Amazon.
 

--- a/study-group/welcome-content.md
+++ b/study-group/welcome-content.md
@@ -8,7 +8,7 @@
 
 Welcome to **the church**.
 
-This is a study group for *Christianity in 24 Hours* — a book that asks what Christianity actually says when you strip away the institutional scaffolding, the political baggage, and the comfortable answers.
+This is a study group for *Christianity Reconstructed in 24 Hours* — a book that asks what Christianity actually says when you strip away the institutional scaffolding, the political baggage, and the comfortable answers.
 
 **How it works:**
 - One chapter per week, 24 weeks


### PR DESCRIPTION
## Summary

- Renames the book from "Christianity in 24 Hours" to "Christianity Reconstructed in 24 Hours" across all 14 files
- Directly counterpoints the deconstruction movement — signals the book rebuilds rather than reaffirms
- Addresses the two-audience problem: the old title attracted mainstream expectations and repelled skeptics; the new title invites the people we most need to reach
- Front cover SVG updated: "Reconstructed" added as a gold accent line between "Christianity" and "in"
- Spine text updated automatically

## Files changed

Manuscript (titlepage, halftitle, copyright), website (index.md, _config.yml), assets (SVG cover, print template, EPUB metadata, KDP metadata), study group materials (pitch, welcome, invitation variants), README, OUTLINE

## Context

Prompted by feedback from Steve Perron at CFI Indiana (secular humanist event, Jun 27) and ongoing discussion about reaching the deconstruction audience.

Closes #—  (no specific issue, but related to the v2 pivot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)