### PR TITLE
Remove declarative "that's the point" in Hours 8 and 13

### DIFF
--- a/manuscript/ch08-moses-and-the-law.md
+++ b/manuscript/ch08-moses-and-the-law.md
@@ -121,7 +121,7 @@ The offense seems minor. At Meribah, God told Moses to speak to a rock and water
 
 This feels disproportionate. A lifetime of faithful service, and one moment of anger at a rock costs you everything?
 
-But that's the point. The standard is the standard. It doesn't bend for seniority. Moses — the greatest leader in the Old Testament — is held to the same accountability as the people he led. No one gets a pass. Not Abraham, who lied about his wife. Not Moses, who struck the rock. The Bible does not protect its heroes from the consequences of their choices.
+But the standard is the standard. It doesn't bend for seniority. Moses — the greatest leader in the Old Testament — is held to the same accountability as the people he led. No one gets a pass. Not Abraham, who lied about his wife. Not Moses, who struck the rock. The Bible does not protect its heroes from the consequences of their choices.
 
 Moses sees the Promised Land from Mount Nebo. He dies there. Joshua leads the people across the Jordan.
 

--- a/manuscript/ch13-love-god-love-neighbor.md
+++ b/manuscript/ch13-love-god-love-neighbor.md
@@ -55,7 +55,7 @@ How do you love yourself? You feed yourself when you're hungry. You protect your
 
 Now do that for the person next to you.
 
-That is an impossible standard. And that's the point. The standard is not designed to be met perfectly — it's designed to be pursued relentlessly. The gap between how you love yourself and how you love your neighbor is the honest measure of where you are. Not where you think you are. Not where your church says you are. Where you actually are.
+That is an impossible standard. The standard is not designed to be met perfectly — it's designed to be pursued relentlessly. The gap between how you love yourself and how you love your neighbor is the honest measure of where you are. Not where you think you are. Not where your church says you are. Where you actually are.
 
 ## Who is your neighbor?
 

--- a/manuscript/ch13-love-god-love-neighbor.md
+++ b/manuscript/ch13-love-god-love-neighbor.md
@@ -55,7 +55,7 @@ How do you love yourself? You feed yourself when you're hungry. You protect your
 
 Now do that for the person next to you.
 
-That is an impossible standard. The standard is not designed to be met perfectly — it's designed to be pursued relentlessly. The gap between how you love yourself and how you love your neighbor is the honest measure of where you are. Not where you think you are. Not where your church says you are. Where you actually are.
+That is an impossible standard. It is not designed to be met perfectly — it's designed to be pursued relentlessly. The gap between how you love yourself and how you love your neighbor is the honest measure of where you are. Not where you think you are. Not where your church says you are. Where you actually are.
 
 ## Who is your neighbor?
 


### PR DESCRIPTION
## Summary
- Audited all instances of "That's the point" / "This is the point" across the manuscript per #144
- Found 3 instances. Evaluation:
  - **Hour 14 (line 5)** — KEPT. Earned by the Q&A reframe structure ("If X, no. If Y, yes. And that's the point.")
  - **Hour 13 (line 58)** — REMOVED. "That is an impossible standard. ~~And that's the point.~~ The standard is not designed to be met perfectly..." The next sentence already explains what the point is — the phrase was redundant throat-clearing.
  - **Hour 8 (line 124)** — REMOVED. "This feels disproportionate... ~~But that's the point.~~ But the standard is the standard." Let the argument carry the weight instead of declaring it.

Addresses #144.

## Test plan
- [x] Verified no remaining unearned instances
- [x] Kept Hour 14's instance (earned, not declarative)
- [x] Both removals leave the surrounding prose stronger

🤖 Generated with [Claude Code](https://claude.com/claude-code)