### PR TITLE
Lead invitations with mission urgency, drop fixed launch date

### DIFF
--- a/study-group/invitation-variants.md
+++ b/study-group/invitation-variants.md
@@ -6,7 +6,7 @@ All variants link to the same resources:
 - Free online: [christianity.trusthumankind.org](https://christianity.trusthumankind.org)
 - Paperback: $9.99 on Amazon
 - Discord: [thechurch.one](https://thechurch.one)
-- Start date: **July 6, 2026**
+- Start date: **Rolling** — begins once a small group is ready, not tied to a calendar date
 
 ---
 
@@ -14,9 +14,11 @@ All variants link to the same resources:
 
 > Hey [Name] —
 >
-> I wrote a book about Christianity. Fair warning: it's not comfortable. It challenges a lot of what we grew up hearing: substitutionary atonement, the Spirit as a personal guidance system, the idea that salvation is an individual transaction. I think the mission got buried under centuries of institutional scaffolding, and the book tries to dig it back out.
+> Quick, real question before anything else: are you actively trying to make some part of the world less cruel — through the church, in your work, wherever? That's what I actually want to build community around.
 >
-> I'm starting a study group. One chapter a week for 24 weeks, starting July 6. Small group, maybe a dozen people. We meet on Discord for weekly discussion threads and one live conversation.
+> I wrote a book about Christianity that might be part of how you'd frame that work. Fair warning: it's not comfortable. It challenges a lot of what we grew up hearing: substitutionary atonement, the Spirit as a personal guidance system, the idea that salvation is an individual transaction. I think the mission got buried under centuries of institutional scaffolding, and the book tries to dig it back out.
+>
+> I'm starting a small study group — one chapter a week for 24 weeks — for people who are already pulling in that direction and want to sharpen it together. We meet on Discord for weekly discussion threads and one live conversation, starting once we've got a small group ready.
 >
 > I want people in this group who will push back. You know the tradition well enough to challenge me where I'm wrong. That's exactly what I need.
 >
@@ -30,11 +32,11 @@ All variants link to the same resources:
 
 > Hey [Name] —
 >
-> I know you're not religious, and that's exactly why I'm reaching out.
+> I know you're not religious, and that's exactly why I'm reaching out — with one question first: are you already trying to make things less unjust, less cruel, less broken, in whatever way you actually work on that? If yes, I think we're already on the same side of the only line that matters to me.
 >
 > I wrote a book called *Christianity Reconstructed in 24 Hours*. It's not what you'd expect. It argues that most of what people associate with Christianity (the politics, the judgment, the prosperity gospel) is a distortion of the actual message. The real mission is simpler and harder: reducing violence, ending poverty, fighting injustice, and building a world that's fair and equitable for everyone. You and I already share that goal. We just come at it from different starting points.
 >
-> I'm starting a study group. One chapter a week for 24 weeks, starting July 6. You don't need to be a Christian. You don't need to believe anything. The group exists to test the book's arguments honestly, and skepticism is more useful than agreement.
+> I'm starting a small study group — one chapter a week for 24 weeks, starting once there's a group ready, not tied to a date. You don't need to be a Christian. You don't need to believe anything. The group exists to test the book's arguments honestly, and skepticism is more useful than agreement.
 >
 > The full text is free at christianity.trusthumankind.org. If you're curious, let me know.
 >
@@ -46,9 +48,11 @@ All variants link to the same resources:
 
 > Hey [Name] —
 >
+> Before the book — one question I've started asking everyone I invite to this: are you already doing something, in whatever field, to make the world less cruel or more just? That's the actual filter. Not whether you agree with a word of the theology.
+>
 > I finished a book I've been working on for a while: *Christianity Reconstructed in 24 Hours*. Twenty-four chapters covering God, Scripture, sin, salvation, the church's history, and where the mission goes from here. It's a theological argument, not devotional reading. The book takes positions and defends them, and some of them (morality is objective, the Spirit isn't actively guiding individuals today, salvation is communal or it's nothing) will probably start arguments.
 >
-> I'm putting together a study group. One chapter per week, 24 weeks, starting July 6. Small group on Discord. The format is async written discussion plus one live conversation per week. I want people who engage with ideas seriously, whether or not they agree with the conclusions.
+> I'm putting together a small study group — one chapter per week, 24 weeks, on Discord — for people who engage with ideas seriously and are already oriented toward doing something with them. Async written discussion plus one live conversation per week. Starting once there's a group, not on a fixed date.
 >
 > The text is free at christianity.trusthumankind.org. Let me know if this is your kind of thing.
 >
@@ -62,7 +66,9 @@ All variants link to the same resources:
 >
 > You know I've been writing this book about faith. It's done: *Christianity Reconstructed in 24 Hours*. I'm proud of it, and I'd love for you to read it, but more than that, I'd love to talk about it with you.
 >
-> I'm starting a study group. One chapter a week for 24 weeks, starting July 6. Small group, about a dozen people. We meet on Discord (I'll help you set it up if you need). Each week there's a discussion thread and one live conversation.
+> Before that, though — I want to ask you something I've started asking everyone: are you already trying to make some part of your life, or someone else's, a little less hard, a little less unjust? That's what this is actually about for me, more than the theology.
+>
+> I'm starting a small study group — one chapter a week for 24 weeks, around a dozen people. We meet on Discord (I'll help you set it up if you need). Each week there's a discussion thread and one live conversation. No fixed start date — we'll begin once there's a group ready.
 >
 > This isn't me preaching. The book takes strong positions and the group exists to challenge them. I want your honest reaction, not your politeness.
 >

--- a/study-group/pitch.md
+++ b/study-group/pitch.md
@@ -2,19 +2,19 @@
 
 Hey —
 
-I wrote a book about faith. Not the comfortable kind. It looks at what Christianity actually says when you strip away the institutional scaffolding, the political baggage, and the "God has a plan" platitudes.
+Before anything else: are you already trying to make some corner of the world less cruel? Doesn't matter how small, doesn't matter if it's rooted in faith or something else entirely. That's the actual thing I'm trying to build community around.
+
+I wrote a book about faith along the way — not the comfortable kind. It looks at what Christianity actually says when you strip away the institutional scaffolding, the political baggage, and the "God has a plan" platitudes.
 
 It's called *Christianity Reconstructed in 24 Hours*. Twenty-four chapters, each readable in under an hour. It covers everything: who God is, what the Bible actually says, why the church got so much wrong, and what it would take to get the mission back on track.
 
 The full text is free online at [christianity.trusthumankind.org](https://christianity.trusthumankind.org). If you prefer a physical copy, the paperback is $9.99 on Amazon.
 
-**I'm starting a study group.** One chapter per week, twenty-four weeks. Small group, around a dozen people. We'll meet on Discord at [thechurch.one](https://thechurch.one) for weekly async threads, with one live discussion.
+**I'm starting a small study group** — one chapter per week, twenty-four weeks, around a dozen people — for people who are already pulling in that direction and want company doing it. We'll meet on Discord at [thechurch.one](https://thechurch.one) for weekly async threads, with one live discussion.
 
-This isn't a Bible study in the traditional sense. No one is going to tell you what to believe. The book takes strong positions, and the study group is where we test them together. Bring your doubt. Bring your pushback. The whole point is honest engagement, not agreement.
+This isn't a Bible study in the traditional sense, and it's not an attempt to win you over to a belief system. No one is going to tell you what to believe. The book takes strong positions, and the study group is where we test them together. Bring your doubt. Bring your pushback. The whole point is honest engagement, not agreement.
 
-**Starting July 6, 2026.** If you're interested, or even just curious, let me know.
-
-You don't need to be a Christian. You don't need to be anything. You just need to be willing to read one chapter a week and show up honestly.
+If that resonates, let me know. I'm not locked to a calendar date — we start once there's a small group of people who actually want to be in it.
 
 — Marty
 

--- a/study-group/welcome-content.md
+++ b/study-group/welcome-content.md
@@ -48,7 +48,7 @@ Quick orientation:
 - **#weekly-discussions** — this is where the study group happens, one thread per week
 - The book is free at christianity.trusthumankind.org
 
-We start **July 6** with Hour 1: God. No prep needed before then — just read the first chapter when you're ready.
+We'll kick off with Hour 1: God once the group's ready — I'll announce the date in #announcements. No prep needed before then — just read the first chapter when you're ready.
 
 If you have questions, #general is the place.
 


### PR DESCRIPTION
## Summary

Reworks the study group invitation materials following a 2026-07-04 pivot: faith alignment doesn't reliably predict mission alignment. Mark Liu's reply to his invitation was full theological overlap with the book's own Christology, but zero visible urgency toward earthly repair — every emphasis upward/future (God's sovereignty, "our home is not here," patient endurance). That's the evidence the original "faith-first, then mission" theory doesn't hold as a recruiting strategy.

**Changes:**
- `pitch.md` and all four `invitation-variants.md` variants (Christian, secular, intellectual, family) now open by asking the actual question that matters — are you already trying to make some corner of the world less cruel — instead of leading with the theology. The book becomes shared language for people already oriented that way, not the on-ramp to get them there.
- Dropped the fixed "July 6, 2026" start date across `pitch.md`, `invitation-variants.md`, and `welcome-content.md` (6 references). Launch is now threshold-based — starts once a small group is actually ready, not tied to a calendar date.

Closes #161.

## Test plan
- [ ] Read each variant as the intended audience — does the urgency framing land without feeling like a screening test?
- [ ] Confirm no remaining fixed-date references anywhere in study-group/
- [ ] Marty's call on whether the tone matches how he'd actually say this to each person

🤖 Generated with [Claude Code](https://claude.com/claude-code)