### PR TITLE
Address gratuitous-evil objection in Hour 17, point forward to Hour 24

### DIFF
--- a/manuscript/ch17-suffering.md
+++ b/manuscript/ch17-suffering.md
@@ -82,9 +82,13 @@ None of those responses address the hardest case: the suffering of the innocent.
 
 There is no theological answer that makes this okay. Any framework that claims to fully explain the suffering of the innocent is lying to you.
 
+A harder question follows close behind: if God can prevent suffering, why not stop just one clear case — one child's cancer — without unraveling anything else? The answer is there's no place to draw that line and mean it. Stop the worst case, and the next-worst case becomes the new worst case by comparison. Follow that logic and you end up needing to prevent everything — no real risk, no real choice, nothing actually at stake. God didn't step back partway. Stepping back was the whole move, not a dial God adjusts case by case.
+
 What can be said is this: the suffering of the innocent is not God's will, God's plan, or God's tool. It is the cost of a world that runs on its own laws. And the mission — the whole mission — is partly about building a world where that suffering is reduced. Every medical breakthrough, every act of care for the vulnerable, every system built to protect the powerless is humanity doing exactly what we were put here to do.
 
 You will encounter suffering you cannot explain. When you do, resist the urge to explain it. Sit with the people who are hurting. Do the practical work of reducing the damage. And carry the mission forward — not because suffering makes sense, but because the response to suffering is where the mission becomes real.
+
+You won't get the full explanation here, and this chapter won't pretend to have one. But the story isn't over. Hour 24 tells you what happens when it is.
 
 ## Questions to sit with
 


### PR DESCRIPTION
## Summary

Closes #163. Two small insertions in Hour 17's "The hardest case" section, no other changes.

Hour 17 already explains why God doesn't micromanage suffering in general — it explicitly names and discards the four weak theodicies, and admits there's no full answer for the suffering of the innocent. What it didn't address is the sharper, more surgical version of the objection: why not intervene in just *one* clear case of suffering, without touching anything else?

Marty and I worked through this in detail (see #163) — his own instinct independently reconstructed a real philosophical position (van Inwagen's "no-minimum" defense), and he connected it to the book's own existing "arc" theology (interventionist era ended, structurally, not case by case) and to Hour 24's debrief, which already promises an answer to exactly this question ("Why the suffering?").

**First insertion** answers "why not just one case," using logic the chapter already established (the "stepped back" framing) — no new theological vocabulary.

**Second insertion** is one line pointing forward to Hour 24, so the chapter's honesty ("no answer now") sits next to what the book already promises ("an answer later"), instead of leaving the two chapters disconnected.

## Test plan
- [ ] Read the new paragraph in context — does it land as an answer, not a dodge?
- [ ] Confirm the Hour 24 pointer doesn't read as a bait-and-switch after "there is no theological answer that makes this okay"

🤖 Generated with [Claude Code](https://claude.com/claude-code)