### PR TITLE
Define recurring core vocabulary, fix Ch04's prior-church-exposure assumption

### DIFF
--- a/manuscript/ch02-the-bible.md
+++ b/manuscript/ch02-the-bible.md
@@ -23,6 +23,8 @@ The Bible is a library. Sixty-six books, written by roughly forty authors, acros
 
 "Breathed out by God" does not mean God dictated it word for word like a CEO sending a memo. The authors of the Bible were real people with real personalities, writing in specific historical contexts for specific audiences. Paul's letters, the Psalms, the Gospel of John, Leviticus, ... The difference in styles is a feature, not a flaw. The Bible's authors each brought their own voice, their own context, their own humanity to the page, and the resulting perspective of God is richer through that diversity.
 
+A quick map, since those names will keep recurring. Roughly the first three-quarters of the Bible's sixty-six books — the Old Testament — cover creation through the centuries before Jesus. The rest — the New Testament — cover Jesus's life and the movement that followed. A "Gospel" is one of four biography-style books about that life; the word itself means "good news," which is also what this book means whenever it says "the gospel" — not just the four books, but the core message they tell. Paul, quoted throughout this book, was a violent opponent of the early church before a conversion so complete he became its most prolific writer (Hour 12 tells that story).
+
 ## What the Bible is not
 
 **It is not a magic 8-ball.** You cannot flip to a random page, point at a verse, and call it God's personal message to you about whether to take that job or date that person. That's superstition dressed up as faith.

--- a/manuscript/ch03-sin.md
+++ b/manuscript/ch03-sin.md
@@ -98,7 +98,7 @@ Sin has an objective definition: choosing self over the mission God gave us. You
 
 **Sin is not about guilt.** Guilt without action is useless. Feeling bad about your choices while continuing to make them is not repentance — it's performance. The point of recognizing sin is to change direction, not to wallow.
 
-**Sin is not a ranking system.** The Pharisees loved to rank sins — to identify which transgressions were worse than others so they could feel superior to the people who committed the bigger ones. Jesus had zero patience for this.
+**Sin is not a ranking system.** The Pharisees — religious leaders in Jesus's time, respected for their strict devotion to the Law — loved to rank sins: identifying which transgressions were worse than others so they could feel superior to the people who committed the bigger ones. Jesus had zero patience for this.
 
 > Why do you see the speck that is in your brother's eye, but do not notice the log that is in your own eye?
 — [Matthew 7:3 ESV][7]

--- a/manuscript/ch03-sin.md
+++ b/manuscript/ch03-sin.md
@@ -98,7 +98,7 @@ Sin has an objective definition: choosing self over the mission God gave us. You
 
 **Sin is not about guilt.** Guilt without action is useless. Feeling bad about your choices while continuing to make them is not repentance — it's performance. The point of recognizing sin is to change direction, not to wallow.
 
-**Sin is not a ranking system.** The Pharisees — religious leaders in Jesus's time, respected for their strict devotion to the Law — loved to rank sins: identifying which transgressions were worse than others so they could feel superior to the people who committed the bigger ones. Jesus had zero patience for this.
+**Sin is not a ranking system.** The Pharisees were religious leaders in Jesus's time, respected for their strict devotion to the Law. And they loved to rank sins: identifying which transgressions were worse than others so they could feel superior to the people who committed the bigger ones. Jesus had zero patience for this.
 
 > Why do you see the speck that is in your brother's eye, but do not notice the log that is in your own eye?
 — [Matthew 7:3 ESV][7]

--- a/manuscript/ch04-salvation.md
+++ b/manuscript/ch04-salvation.md
@@ -56,7 +56,7 @@ Read that carefully. Not "after we cleaned ourselves up." Not "once we proved we
 
 Grace is not permission to keep failing. It is the assurance that the mission — the team — still wants you and needs you even when you falter. You'll fall off the path, and you can get back on. There is always an on-ramp for you just ahead.
 
-Peter — one of Jesus's closest followers — denied Jesus three times the night before the crucifixion, after swearing he never would ([Luke 22:54-62][5]). After Jesus rose from death (the resurrection — Hour 11 tells that story in full), Jesus found Peter and asked him one question, three times: "Do you love me?" Three chances to reverse three denials. No lecture. No punishment. No probationary period. Just: do you love me? Yes? Then feed my sheep ([John 21:15-17][6]).
+Peter — one of Jesus's closest followers — denied Jesus three times the night before the crucifixion, after swearing he never would ([Luke 22:54-62][5]). When Jesus rose from death in an event commonly called the resurrection (Hour 11 tells that story in full), Jesus found Peter and asked him one question, three times: "Do you love me?" Three chances to reverse three denials. No lecture. No punishment. No probationary period. Just: do you love me? Yes? Then feed my sheep ([John 21:15-17][6]).
 
 That is grace. Not the absence of accountability — Peter had to face what he did. But Jesus refused to let failure be the final word.
 

--- a/manuscript/ch04-salvation.md
+++ b/manuscript/ch04-salvation.md
@@ -14,7 +14,7 @@ No. The test was never pass/fail on the first attempt. And the test may not be o
 
 ## What salvation means
 
-Strip away everything you've heard about salvation in church — the altar calls, the sinner's prayer, the "accept Jesus into your heart" formula — and ask the simplest possible question: saved from what?
+In many churches, salvation gets reduced to a single moment: walking to the front of a room during an altar call, reciting a specific prayer, "accepting Jesus into your heart." Strip away that ritual and ask the simplest possible question: saved from what?
 
 The standard Christian answer is: saved from hell. Saved from God's wrath. Saved from the eternal consequences of your sin.
 
@@ -56,7 +56,7 @@ Read that carefully. Not "after we cleaned ourselves up." Not "once we proved we
 
 Grace is not permission to keep failing. It is the assurance that the mission — the team — still wants you and needs you even when you falter. You'll fall off the path, and you can get back on. There is always an on-ramp for you just ahead.
 
-Peter denied Jesus three times the night before the crucifixion — after swearing he never would ([Luke 22:54-62][5]). After the resurrection, Jesus found Peter and asked him one question, three times: "Do you love me?" Three chances to reverse three denials. No lecture. No punishment. No probationary period. Just: do you love me? Yes? Then feed my sheep ([John 21:15-17][6]).
+Peter — one of Jesus's closest followers — denied Jesus three times the night before the crucifixion, after swearing he never would ([Luke 22:54-62][5]). After Jesus rose from death (the resurrection — Hour 11 tells that story in full), Jesus found Peter and asked him one question, three times: "Do you love me?" Three chances to reverse three denials. No lecture. No punishment. No probationary period. Just: do you love me? Yes? Then feed my sheep ([John 21:15-17][6]).
 
 That is grace. Not the absence of accountability — Peter had to face what he did. But Jesus refused to let failure be the final word.
 

--- a/manuscript/ch10-jesus-the-life.md
+++ b/manuscript/ch10-jesus-the-life.md
@@ -21,7 +21,7 @@ He was a carpenter's son. He worked with his hands. He didn't emerge from a pala
 > The Spirit of the Lord is upon me, because he has anointed me to proclaim good news to the poor. He has sent me to proclaim liberty to the captives and recovering of sight to the blind, to set at liberty those who are oppressed.
 — [Luke 4:18 ESV][1]
 
-Those are Jesus's own words, reading Isaiah in his hometown synagogue — claiming the prophetic mantle. Anointed and sent, like Moses, like Elijah. The centuries of prophecy pointed to this man. But the distinction that matters for everything that follows: unlike every prophet before him, Jesus would carry the mission all the way without faltering. Moses struck the rock. David fell with Bathsheba. Solomon turned to other gods. Jesus held.
+Those are Jesus's own words, reading Isaiah aloud in his hometown synagogue — the local building where Jews gathered to worship and study Scripture — claiming the prophetic mantle. Anointed and sent, like Moses, like Elijah. The centuries of prophecy pointed to this man. But the distinction that matters for everything that follows: unlike every prophet before him, Jesus would carry the mission all the way without faltering. Moses struck the rock. David fell with Bathsheba. Solomon turned to other gods. Jesus held.
 
 ## What he taught
 
@@ -54,6 +54,8 @@ When a rich young man asked what he must do to inherit eternal life, Jesus told 
 > Jesus said to his disciples, "Truly, I say to you, only with difficulty will a rich person enter the kingdom of heaven."
 — [Matthew 19:23 ESV][8]
 
+The "kingdom of heaven" — a phrase that recurs through the rest of this book — isn't a place you go when you die. It's Jesus's shorthand for God's reign actually taking hold: people living the mission, here, now, whether or not any government or institution recognizes it.
+
 This is faith made visible. Not belief. Not ritual. A direction. A willingness to orient your life around the mission even when the cost is everything comfortable about your current one.
 
 ## The parables
@@ -68,7 +70,7 @@ These parables are not illustrations. They are the mission statement. Love the p
 
 ## Who he challenged
 
-Jesus reserved his sharpest criticism not for sinners but for the religious establishment.
+Jesus reserved his sharpest criticism not for sinners but for the religious establishment — the scribes (legal scholars who copied and interpreted Scripture) and the Pharisees (Hour 3).
 
 > Woe to you, scribes and Pharisees, hypocrites! For you tithe mint and dill and cumin, and have neglected the weightier matters of the law: justice and mercy and faithfulness.
 — [Matthew 23:23 ESV][11]
@@ -83,7 +85,7 @@ The religious leaders responded the way institutional power always does when con
 
 Equally important is what Jesus did not do.
 
-He did not establish an earthly kingdom. Israel expected a messiah who would overthrow Rome, restore the monarchy, and reign from David's throne. Jesus refused that role so consistently that people who followed him for the miracles and the food eventually left because he wouldn't be the political leader they wanted.
+He did not establish an earthly kingdom. Israel expected a messiah — a promised, anointed rescuer, a word that means "anointed one" — who would overthrow Rome, restore the monarchy, and reign from David's throne. Jesus refused that role so consistently that people who followed him for the miracles and the food eventually left because he wouldn't be the political leader they wanted.
 
 > Jesus answered, "My kingdom is not of this world. If my kingdom were of this world, my servants would have been fighting, that I might not be handed over to the Jews. But my kingdom is not from the world."
 — [John 18:36 ESV][12]

--- a/manuscript/ch10-jesus-the-life.md
+++ b/manuscript/ch10-jesus-the-life.md
@@ -21,7 +21,7 @@ He was a carpenter's son. He worked with his hands. He didn't emerge from a pala
 > The Spirit of the Lord is upon me, because he has anointed me to proclaim good news to the poor. He has sent me to proclaim liberty to the captives and recovering of sight to the blind, to set at liberty those who are oppressed.
 — [Luke 4:18 ESV][1]
 
-Those are Jesus's own words, reading Isaiah aloud in his hometown synagogue — the local building where Jews gathered to worship and study Scripture — claiming the prophetic mantle. Anointed and sent, like Moses, like Elijah. The centuries of prophecy pointed to this man. But the distinction that matters for everything that follows: unlike every prophet before him, Jesus would carry the mission all the way without faltering. Moses struck the rock. David fell with Bathsheba. Solomon turned to other gods. Jesus held.
+Those are Jesus's own words spoken in his hometown synagogue, the local building where Jews gathered to worship and study Scripture. By reading Isaiah aloud there, Jesus claimed the prophetic mantle. Anointed and sent, like Moses, like Elijah. The centuries of prophecy pointed to this man. But the distinction that matters for everything that follows: unlike every prophet before him, Jesus would carry the mission all the way without faltering. Moses struck the rock. David fell with Bathsheba. Solomon turned to other gods. Jesus held.
 
 ## What he taught
 
@@ -54,7 +54,7 @@ When a rich young man asked what he must do to inherit eternal life, Jesus told 
 > Jesus said to his disciples, "Truly, I say to you, only with difficulty will a rich person enter the kingdom of heaven."
 — [Matthew 19:23 ESV][8]
 
-The "kingdom of heaven" — a phrase that recurs through the rest of this book — isn't a place you go when you die. It's Jesus's shorthand for God's reign actually taking hold: people living the mission, here, now, whether or not any government or institution recognizes it.
+The "kingdom of heaven" isn't a place you go when you die. It's Jesus's shorthand for God's reign actually taking hold: people living the mission, here, now, whether or not any government or institution recognizes it.
 
 This is faith made visible. Not belief. Not ritual. A direction. A willingness to orient your life around the mission even when the cost is everything comfortable about your current one.
 
@@ -70,7 +70,7 @@ These parables are not illustrations. They are the mission statement. Love the p
 
 ## Who he challenged
 
-Jesus reserved his sharpest criticism not for sinners but for the religious establishment — the scribes (legal scholars who copied and interpreted Scripture) and the Pharisees (Hour 3).
+Jesus reserved his sharpest criticism not for sinners but for the religious establishment. This included the scribes: legal scholars who copied and interpreted Scripture. And this included the Pharisees (Hour 3).
 
 > Woe to you, scribes and Pharisees, hypocrites! For you tithe mint and dill and cumin, and have neglected the weightier matters of the law: justice and mercy and faithfulness.
 — [Matthew 23:23 ESV][11]
@@ -85,7 +85,7 @@ The religious leaders responded the way institutional power always does when con
 
 Equally important is what Jesus did not do.
 
-He did not establish an earthly kingdom. Israel expected a messiah — a promised, anointed rescuer, a word that means "anointed one" — who would overthrow Rome, restore the monarchy, and reign from David's throne. Jesus refused that role so consistently that people who followed him for the miracles and the food eventually left because he wouldn't be the political leader they wanted.
+He did not establish an earthly kingdom. Israel expected a messiah — a promised, anointed rescuer known as the "anointed one" — who would overthrow Rome, restore the monarchy, and reign from David's throne. Jesus refused that role so consistently that people who followed him for the miracles and the food eventually left because he wouldn't be the political leader they wanted.
 
 > Jesus answered, "My kingdom is not of this world. If my kingdom were of this world, my servants would have been fighting, that I might not be handed over to the Jews. But my kingdom is not from the world."
 — [John 18:36 ESV][12]

--- a/manuscript/ch12-the-early-church.md
+++ b/manuscript/ch12-the-early-church.md
@@ -12,7 +12,7 @@ This chapter is about what they did next. And why it matters that they did it im
 
 ## Pentecost
 
-Pentecost — the Jewish harvest festival held fifty days after Passover, one of the yearly feasts that drew pilgrims to Jerusalem from across the empire — had arrived. The disciples were gathered in the city. They were waiting — Jesus had told them to wait for the promise ([Acts 1:4][1]). They didn't know what they were waiting for.
+Pentecost was and still is the Jewish harvest festival held fifty days after Passover. Pentecost was one of the yearly feasts that drew pilgrims to Jerusalem from across the Roman Empire. When the festival arrived after Jesus's resurrection, the disciples were gathered in the city. Jesus had told them to wait for the promise ([Acts 1:4][1]), but the disciples didn't know what they were waiting for.
 
 Then the Spirit came.
 
@@ -72,7 +72,7 @@ To everyone. Not just Israel. Not just the covenant people. The mission that beg
 
 The early church was not a movement of saints. It was a movement of people, and people argue.
 
-The first major crisis was the question of Gentile inclusion. Did non-Jews (Gentiles) have to become Jewish first — circumcision (the ancient sign marking a man as part of God's covenant people), dietary laws, the full Law of Moses — before they could follow Jesus? This was not a trivial question. It was the question of whether the mission was for everyone or only for the people who already had the cultural prerequisites.
+The first major crisis was the question of Gentile inclusion. Did these Gentiles or non-Jews have to become Jewish first? Did Gentiles have to undergo circumcision (the ancient mark of God's covenant people), adopt the same dietary laws, and learn the full Law of Moses before they could follow Jesus? This was not a trivial question. It was the question of whether the mission was for everyone or only for the people who already had the cultural prerequisites.
 
 The Jerusalem Council (Acts 15) settled it: Gentiles did not need to become Jews. The mission was universal. But the debate was fierce, and echoes of it run through Paul's letters for years. Peter himself wavered — eating with Gentiles when no one was looking, then pulling back when Jewish Christians showed up. Paul confronted him publicly:
 

--- a/manuscript/ch12-the-early-church.md
+++ b/manuscript/ch12-the-early-church.md
@@ -12,7 +12,7 @@ This chapter is about what they did next. And why it matters that they did it im
 
 ## Pentecost
 
-Fifty days after the resurrection, the disciples were gathered in Jerusalem. They were waiting — Jesus had told them to wait for the promise ([Acts 1:4][1]). They didn't know what they were waiting for.
+Pentecost — the Jewish harvest festival held fifty days after Passover, one of the yearly feasts that drew pilgrims to Jerusalem from across the empire — had arrived. The disciples were gathered in the city. They were waiting — Jesus had told them to wait for the promise ([Acts 1:4][1]). They didn't know what they were waiting for.
 
 Then the Spirit came.
 
@@ -72,12 +72,14 @@ To everyone. Not just Israel. Not just the covenant people. The mission that beg
 
 The early church was not a movement of saints. It was a movement of people, and people argue.
 
-The first major crisis was the question of Gentile inclusion. Did non-Jews have to become Jewish first — circumcision, dietary laws, the full Law of Moses — before they could follow Jesus? This was not a trivial question. It was the question of whether the mission was for everyone or only for the people who already had the cultural prerequisites.
+The first major crisis was the question of Gentile inclusion. Did non-Jews (Gentiles) have to become Jewish first — circumcision (the ancient sign marking a man as part of God's covenant people), dietary laws, the full Law of Moses — before they could follow Jesus? This was not a trivial question. It was the question of whether the mission was for everyone or only for the people who already had the cultural prerequisites.
 
 The Jerusalem Council (Acts 15) settled it: Gentiles did not need to become Jews. The mission was universal. But the debate was fierce, and echoes of it run through Paul's letters for years. Peter himself wavered — eating with Gentiles when no one was looking, then pulling back when Jewish Christians showed up. Paul confronted him publicly:
 
 > But when Cephas came to Antioch, I opposed him to his face, because he stood condemned.
 — [Galatians 2:11 ESV][11]
+
+(Cephas is Peter's other name — Aramaic for the same word Jesus used when he called him "the rock.")
 
 Peter, the rock on which Jesus said the church would be built, compromising the mission out of social pressure. Paul, the former persecutor, calling him out. The early church was messy, political, and human in every way. That is not a weakness of the narrative. It is the point.
 


### PR DESCRIPTION
## Summary

Addresses the Priority 1–3 findings from #166 (the zero-church-background audit that followed #142 / STYLE.md).

- **Ch02:** defines "the gospel," the Old/New Testament split, and introduces Paul at his first appearance instead of treating him as already-known for the rest of the book. This is the root-cause fix for "the gospel" being used constantly but never defined anywhere.
- **Ch03:** identifies the Pharisees at their first mention — they recur in 6+ later chapters.
- **Ch04:** rewrites the line that assumed prior church exposure ("everything you've heard about salvation in church" — altar calls, the sinner's prayer), which directly contradicted the new persona standard. Also explains "the resurrection" (with a forward pointer to Hour 11, which hasn't happened yet at this point in the book) and introduces Peter.
- **Ch10:** defines "messiah," "synagogue," "kingdom of heaven," and "scribes" at the exact point each becomes load-bearing — this was flagged as the chapter with the most significant gaps in the audit.
- **Ch12:** moves "Pentecost" from a bare section header into an explained term in the body text, clarifies "Cephas" as Peter's other name (previously read as a brand-new, unexplained character), and glosses "circumcision" and "Gentiles."

## Not included

Priority 4 findings (scattered one-off unexplained names — Aaron, Samuel, Judas, Barabbas, Lazarus, Martha/Mary, John Mark, and others) are left for a follow-up pass. Tracked in #166, which stays open until those are addressed.

## Test plan
- [ ] Read each changed passage in context — do the additions read as natural explanation, not a stopped-to-lecture interruption?
- [ ] Confirm Ch04's rewritten line still lands the same rhetorical point (that church culture often reduces salvation to a moment) without assuming the reader has witnessed it

🤖 Generated with [Claude Code](https://claude.com/claude-code)