### PR TITLE
Make explicit that the mission and the two commandments are one thing

### DIFF
--- a/manuscript/ch01-god.md
+++ b/manuscript/ch01-god.md
@@ -31,7 +31,7 @@ God created humanity with a mission, a test. Think of it this way: God has a vis
 
 Earth is our sacred domain. And "dominion" is not a trophy; it's a responsibility. You were made in the image of God — not to sit on a throne, but to steward what God built.
 
-What does that stewardship actually look like, day to day? The answer's at the end of this chapter.
+What does that stewardship actually look like, day to day? Taking responsibility for what God actually built and gave you: the earth, and the people living on it.
 
 ## Who is Satan, really?
 
@@ -72,7 +72,7 @@ Jesus answered this directly. No ambiguity, no fine print.
 
 Love God. Love other people. Everything else in the Bible hangs on those two commands.
 
-Loving God is not a feeling toward someone who has never spoken to you. If it were only that, the objection is fair: how do you love a God who stays silent while the world gets this cruel, and call it love with a straight face? But loving God has a concrete shape. It means caring for what God actually built and handed to you. That is the dominion from a few paragraphs ago. Not affection for someone distant. Responsibility for something real.
+Loving God is not a feeling toward someone who has never spoken to you. How do you love a God who stays silent while the world can be downright cruel? Then call it love with a straight face? You don't. What Jesus meant was stewardship over the earth that God created. In other words: take care of our environment, our planet. Loving God is not faking affection for someone distant but taking responsibility for something real.
 
 Whether we can take and hold that responsibility _is_ the test with Satan. By loving God and loving your neighbor at global scale, we prove Satan wrong. Failure would be either destroying our planet or pitting ourselves against each other in constant conflict with winners and losers.
 

--- a/manuscript/ch01-god.md
+++ b/manuscript/ch01-god.md
@@ -31,6 +31,8 @@ God created humanity with a mission, a test. Think of it this way: God has a vis
 
 Earth is our sacred domain. And "dominion" is not a trophy; it's a responsibility. You were made in the image of God — not to sit on a throne, but to steward what God built.
 
+What does that stewardship actually look like, day to day? Hold that question. This chapter answers it by the end, and the answer is simpler than the setup makes it sound.
+
 ## Who is Satan, really?
 
 Here's where things part ways with most of what you've heard.
@@ -68,7 +70,9 @@ Jesus answered this directly. No ambiguity, no fine print.
 > You shall love the Lord your God with all your heart and with all your soul and with all your mind. This is the great and first commandment. And a second is like it: You shall love your neighbor as yourself. On these two commandments depend all the Law and the Prophets.
 — [Matthew 22:37-40 ESV][5]
 
-Love God. Love other people. Everything else in the Bible hangs on those two commands. And notice: the mission — stewarding the earth, taking care of each other, proving we can do this — is really just a concrete expression of those two commandments lived out at scale.
+Love God. Love other people. Everything else in the Bible hangs on those two commands.
+
+Here is how that connects to everything else in this chapter. The test with Satan, the mission to steward the earth, proving that we can get this right — none of that is a separate goal from loving God and loving your neighbor. It's the same goal, described at two different scales. Loving God and loving your neighbor is what the mission actually looks like, moment to moment, choice by choice. You prove Satan wrong by loving well. That is the whole test.
 
 Simple to understand. Extraordinarily difficult to live. And that tension between understanding and living is what you'll explore in the coming chapters.
 

--- a/manuscript/ch01-god.md
+++ b/manuscript/ch01-god.md
@@ -74,7 +74,7 @@ Love God. Love other people. Everything else in the Bible hangs on those two com
 
 Loving God is not a feeling toward someone who has never spoken to you. If it were only that, the objection is fair: how do you love a God who stays silent while the world gets this cruel, and call it love with a straight face? But loving God has a concrete shape. It means caring for what God actually built and handed to you. That is the dominion from a few paragraphs ago. Not affection for someone distant. Responsibility for something real.
 
-Here is how that connects to everything else in this chapter. The test with Satan and the mission to steward the earth are not separate from loving God and loving your neighbor. They are the same goal. Proving that we can get this right is loving God and loving your neighbor, lived out at scale. You prove Satan wrong by loving well. That is the whole test.
+Whether we can take and hold that responsibility _is_ the test with Satan. By loving God and loving your neighbor at global scale, we prove Satan wrong. Failure would be either destroying our planet or pitting ourselves against each other in constant conflict with winners and losers.
 
 Simple to understand. Extraordinarily difficult to live. And that tension between understanding and living is what you'll explore in the coming chapters.
 

--- a/manuscript/ch01-god.md
+++ b/manuscript/ch01-god.md
@@ -72,7 +72,7 @@ Jesus answered this directly. No ambiguity, no fine print.
 
 Love God. Love other people. Everything else in the Bible hangs on those two commands.
 
-Loving God is not a feeling toward someone who has never spoken to you. How do you love a God who stays silent while the world can be downright cruel? Then call it love with a straight face? You don't. Jesus was talking about stewardship over the earth that God created. In other words: take care of our environment, our planet. Loving God is not faking affection for someone distant but taking responsibility for something real.
+Loving God is not a feeling toward someone who has never spoken to you. How do you love a God who silently allows cruelty and injustice in the world? How can you say "I love God" with a straight face? Jesus was talking about stewardship over the earth that God created. In other words: take care of our environment, our planet. Loving God is not faking affection for someone distant but taking responsibility for something real.
 
 Whether we can take and hold that responsibility _is_ the test with Satan. By loving God and loving your neighbor at global scale, we prove Satan wrong. Failure would be either destroying our planet or pitting ourselves against each other in constant conflict with winners and losers.
 

--- a/manuscript/ch01-god.md
+++ b/manuscript/ch01-god.md
@@ -31,7 +31,7 @@ God created humanity with a mission, a test. Think of it this way: God has a vis
 
 Earth is our sacred domain. And "dominion" is not a trophy; it's a responsibility. You were made in the image of God — not to sit on a throne, but to steward what God built.
 
-What does that stewardship actually look like, day to day? Hold that question. This chapter answers it by the end, and the answer is simpler than the setup makes it sound.
+What does that stewardship actually look like, day to day? The answer's at the end of this chapter.
 
 ## Who is Satan, really?
 
@@ -72,7 +72,9 @@ Jesus answered this directly. No ambiguity, no fine print.
 
 Love God. Love other people. Everything else in the Bible hangs on those two commands.
 
-Here is how that connects to everything else in this chapter. The test with Satan, the mission to steward the earth, proving that we can get this right — none of that is a separate goal from loving God and loving your neighbor. It's the same goal, described at two different scales. Loving God and loving your neighbor is what the mission actually looks like, moment to moment, choice by choice. You prove Satan wrong by loving well. That is the whole test.
+Loving God is not a feeling toward someone who has never spoken to you. If it were only that, the objection is fair: how do you love a God who stays silent while the world gets this cruel, and call it love with a straight face? But loving God has a concrete shape. It means caring for what God actually built and handed to you. That is the dominion from a few paragraphs ago. Not affection for someone distant. Responsibility for something real.
+
+Here is how that connects to everything else in this chapter. The test with Satan and the mission to steward the earth are not separate from loving God and loving your neighbor. They are the same goal. Proving that we can get this right is loving God and loving your neighbor, lived out at scale. You prove Satan wrong by loving well. That is the whole test.
 
 Simple to understand. Extraordinarily difficult to live. And that tension between understanding and living is what you'll explore in the coming chapters.
 

--- a/manuscript/ch01-god.md
+++ b/manuscript/ch01-god.md
@@ -72,7 +72,7 @@ Jesus answered this directly. No ambiguity, no fine print.
 
 Love God. Love other people. Everything else in the Bible hangs on those two commands.
 
-Loving God is not a feeling toward someone who has never spoken to you. How do you love a God who silently allows cruelty and injustice in the world? How can you say "I love God" with a straight face? Jesus was talking about stewardship over the earth that God created. In other words: take care of our environment, our planet. Loving God is not faking affection for someone distant but taking responsibility for something real.
+Loving God is not a feeling toward someone who has never spoken to you. How do you love a God who silently allows cruelty and injustice in the world? How can you say "I love God" with a straight face? You don't. Jesus was talking about stewardship over the earth that God created. In other words: take care of our environment, our planet. Loving God is not faking affection for someone distant but taking responsibility for something real.
 
 Whether we can take and hold that responsibility _is_ the test with Satan. By loving God and loving your neighbor at global scale, we prove Satan wrong. Failure would be either destroying our planet or pitting ourselves against each other in constant conflict with winners and losers.
 

--- a/manuscript/ch01-god.md
+++ b/manuscript/ch01-god.md
@@ -72,7 +72,7 @@ Jesus answered this directly. No ambiguity, no fine print.
 
 Love God. Love other people. Everything else in the Bible hangs on those two commands.
 
-Loving God is not a feeling toward someone who has never spoken to you. How do you love a God who stays silent while the world can be downright cruel? Then call it love with a straight face? You don't. What Jesus meant was stewardship over the earth that God created. In other words: take care of our environment, our planet. Loving God is not faking affection for someone distant but taking responsibility for something real.
+Loving God is not a feeling toward someone who has never spoken to you. How do you love a God who stays silent while the world can be downright cruel? Then call it love with a straight face? You don't. Jesus was talking about stewardship over the earth that God created. In other words: take care of our environment, our planet. Loving God is not faking affection for someone distant but taking responsibility for something real.
 
 Whether we can take and hold that responsibility _is_ the test with Satan. By loving God and loving your neighbor at global scale, we prove Satan wrong. Failure would be either destroying our planet or pitting ourselves against each other in constant conflict with winners and losers.
 


### PR DESCRIPTION
## Summary

Closes #145. Hour 1 builds the "mission = proving Satan wrong" framing across three sections (the test, Satan, free will) before connecting it to "love God, love your neighbor" in a single buried clause at the very end ("And notice: ..."). A beta reader read it twice and still couldn't tell if these were the same mission or two different ones.

Two small changes:
- A forward-pointing question right after "steward what God built," so the reader knows a concrete answer is coming rather than being surprised by it at the chapter's end.
- A rewritten closing paragraph that states plainly: these are the same goal described at two scales, not two goals. "You prove Satan wrong by loving well."

## Test plan
- [ ] Read Hour 1 straight through — is the connection between the cosmic test and the two commandments clear on a single read now?

🤖 Generated with [Claude Code](https://claude.com/claude-code)