### PR TITLE
Fix double blank pages at every Part boundary

### DIFF
--- a/assets/kdp-metadata.yaml
+++ b/assets/kdp-metadata.yaml
@@ -55,6 +55,6 @@ pricing:
 format:
   trim: "5.06 x 7.81 inches"
   interior: "black and white interior, white paper"  # confirmed against live KDP dashboard 2026-07-05 — matches the cover SVG's assumption
-  pages: 251
+  pages: 243  # corrected after fixing the double-blank-page bug (was 251)
   isbn: "Free KDP ISBN (assigned at upload)"
 ---

--- a/assets/print-template.typ
+++ b/assets/print-template.typ
@@ -155,7 +155,10 @@
         align(center + horizon)[
           #text(size: 20pt, weight: "bold", fill: black)[#it.body]
         ]
-        pagebreak(to: "odd")
+        // No trailing pagebreak here — the next H1 (a regular chapter)
+        // now forces its own pagebreak(to: "odd"), so adding one here
+        // too produced two extra blank pages before every chapter that
+        // opens a Part.
         return
       }
 


### PR DESCRIPTION
## Summary

Found and fixed the bug Marty reported: back-to-back blank pages at 15-16, 65-66, 131-132, 189-190 (one pair per Part boundary).

**Root cause:** the Part-separator branch forced `pagebreak(to: "odd")` both before and after rendering the Part title. The trailing one existed because regular chapters used to use a *weak* pagebreak (a no-op if already at a fresh page). When I changed regular chapters to force recto starts (previous commit), the chapter immediately following a Part title started forcing its *own* `pagebreak(to: "odd")` too — so the two calls compounded into two blank pages instead of the intended one.

**Fix:** removed the now-redundant trailing pagebreak from the Part branch. Verified all four Part boundaries in the rebuilt PDF: title on an odd page, exactly one blank even page, next chapter starts on the following odd page.

**Page count: 251 → 243.** Updated `kdp-metadata.yaml` to match.

## Follow-up needed

Since the page count changed again, the cover's spine width (currently sized for 251 pages) is now stale by 8 pages. Will need another KDP template download for 243 pages before the cover is final — flagging here so it's not missed before upload.

## Test plan
- [ ] Confirm pages 15-16, 65-66 (now shifted), 131-132 (now shifted), 189-190 (now shifted) in a fresh build show exactly one blank page per Part boundary, not two

🤖 Generated with [Claude Code](https://claude.com/claude-code)